### PR TITLE
Attempt to fix helm install crds.

### DIFF
--- a/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
+++ b/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
@@ -4,10 +4,12 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    {{- with .Values.crds.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
     controller-gen.kubebuilder.io/version: (devel)
+    {{if gt (len .Values.crds.annotations) 0 }}
+      {{- with .Values.crds.annotations }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
   creationTimestamp: null
   name: redisfailovers.databases.spotahome.com
 spec:


### PR DESCRIPTION
Fixes a current issue in the original repo and this fork where the helm install fails with a conversion error:
```
helm install redis-operator https://github.com/Saremox/redis-operator/releases/download/Chart-3.4.0/redis-operator-3.4.0.tgz -n redis-operator --create-namespace
Error: INSTALLATION FAILED: failed to install CRD crds/databases.spotahome.com_redisfailovers.yaml: error parsing : error converting YAML to JSON: yaml: line 4: did not find expected node content
```

