### PR TITLE
Update Redis Operator image link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,8 @@ kubectl delete redisfailover <NAME>
 
 ### Redis Operator
 
-[![Redis Operator Image](https://quay.io/repository/spotahome/redis-operator/status "Redis Operator Image")](https://quay.io/repository/spotahome/redis-operator)
+* [Redis Operator Image](https://github.com/Saremox/redis-operator/pkgs/container/redis-operator)
+
 ## Documentation
 
 For the code documentation, you can lookup on the [GoDoc](https://godoc.org/github.com/Saremox/redis-operator).


### PR DESCRIPTION
As the old link was still referencing spotahome's outdated image

This removes the badge, as I was not able to quickly find a way to show it for an image in GHCR