### PR TITLE
fix: PDB generation is now component-safe

### DIFF
--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -87,7 +87,7 @@ func (r *RedisFailoverKubeClient) EnsureSentinelConfigMap(rf *redisfailoverv1.Re
 // EnsureSentinelDeployment makes sure the sentinel deployment exists in the desired state
 func (r *RedisFailoverKubeClient) EnsureSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
 	if !rf.Spec.Sentinel.DisablePodDisruptionBudget {
-		if err := r.ensurePodDisruptionBudget(rf, sentinelName, sentinelRoleName, labels, ownerRefs); err != nil {
+		if err := r.ensurePodDisruptionBudget(rf, sentinelName, sentinelRoleName, labels, ownerRefs, rf.Spec.Sentinel.Replicas); err != nil {
 			return err
 		}
 	}
@@ -101,7 +101,7 @@ func (r *RedisFailoverKubeClient) EnsureSentinelDeployment(rf *redisfailoverv1.R
 // EnsureRedisStatefulset makes sure the redis statefulset exists in the desired state
 func (r *RedisFailoverKubeClient) EnsureRedisStatefulset(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
 	if !rf.Spec.Redis.DisablePodDisruptionBudget {
-		if err := r.ensurePodDisruptionBudget(rf, redisName, redisRoleName, labels, ownerRefs); err != nil {
+		if err := r.ensurePodDisruptionBudget(rf, redisName, redisRoleName, labels, ownerRefs, rf.Spec.Redis.Replicas); err != nil {
 			return err
 		}
 	}
@@ -229,19 +229,21 @@ func (r *RedisFailoverKubeClient) EnsureRedisSlaveService(rf *redisfailoverv1.Re
 	return err
 }
 
-// EnsureRedisStatefulset makes sure the pdb exists in the desired state
-func (r *RedisFailoverKubeClient) ensurePodDisruptionBudget(rf *redisfailoverv1.RedisFailover, name string, component string, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
+// ensurePodDisruptionBudget creates or updates a PDB for the given component.
+// replicas must be the replica count of the component being protected (not a different component).
+func (r *RedisFailoverKubeClient) ensurePodDisruptionBudget(rf *redisfailoverv1.RedisFailover, name string, component string, labels map[string]string, ownerRefs []metav1.OwnerReference, replicas int32) error {
 	name = generateName(name, rf.Name)
 	namespace := rf.Namespace
 
 	minAvailable := intstr.FromInt(2)
-	if rf.Spec.Redis.Replicas <= 2 {
+	if replicas <= 2 {
 		minAvailable = intstr.FromInt(1)
 	}
 
-	labels = util.MergeLabels(labels, generateSelectorLabels(component, rf.Name))
+	selectorLabels := generateSelectorLabels(component, rf.Name)
+	metaLabels := util.MergeLabels(labels, selectorLabels)
 
-	pdb := generatePodDisruptionBudget(name, namespace, labels, ownerRefs, minAvailable)
+	pdb := generatePodDisruptionBudget(name, namespace, metaLabels, ownerRefs, minAvailable, selectorLabels)
 	err := r.K8SService.CreateOrUpdatePodDisruptionBudget(namespace, pdb)
 	r.setEnsureOperationMetrics(pdb.Namespace, pdb.Name, "PodDisruptionBudget" /* pdb.TypeMeta.Kind isnt working;  pdb.Kind isnt working either */, rf.Name, err)
 	return err

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -671,7 +671,7 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 	return sd
 }
 
-func generatePodDisruptionBudget(name string, namespace string, labels map[string]string, ownerRefs []metav1.OwnerReference, minAvailable intstr.IntOrString) *policyv1.PodDisruptionBudget {
+func generatePodDisruptionBudget(name string, namespace string, labels map[string]string, ownerRefs []metav1.OwnerReference, minAvailable intstr.IntOrString, selectorLabels map[string]string) *policyv1.PodDisruptionBudget {
 	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
@@ -682,7 +682,7 @@ func generatePodDisruptionBudget(name string, namespace string, labels map[strin
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: selectorLabels,
 			},
 		},
 	}

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -2791,4 +2792,162 @@ func TestSentinelCustomStartupProbe(t *testing.T) {
 		assert.NoError(err)
 		assert.Equal(test.expectedStartupProbe, startupProbe)
 	}
+}
+
+func TestRedisPDBUsesRedisReplicaCount(t *testing.T) {
+	tests := []struct {
+		name             string
+		redisReplicas    int32
+		sentinelReplicas int32
+		expectedMin      intstr.IntOrString
+	}{
+		{
+			name:             "Redis replicas > 2 gives minAvailable 2",
+			redisReplicas:    3,
+			sentinelReplicas: 1, // should not affect Redis PDB
+			expectedMin:      intstr.FromInt(2),
+		},
+		{
+			name:             "Redis replicas <= 2 gives minAvailable 1",
+			redisReplicas:    2,
+			sentinelReplicas: 5, // should not affect Redis PDB
+			expectedMin:      intstr.FromInt(1),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			rf := generateRF()
+			rf.Spec.Redis.Replicas = test.redisReplicas
+			rf.Spec.Sentinel.Replicas = test.sentinelReplicas
+
+			var gotPDB *policyv1.PodDisruptionBudget
+			ms := &mK8SService.Services{}
+			ms.On("CreateOrUpdatePodDisruptionBudget", namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
+				gotPDB = args.Get(1).(*policyv1.PodDisruptionBudget)
+			}).Return(nil)
+			ms.On("CreateOrUpdateStatefulSet", namespace, mock.Anything).Once().Return(nil)
+
+			client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+			err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
+
+			assert.NoError(err)
+			assert.NotNil(gotPDB)
+			assert.Equal(test.expectedMin, *gotPDB.Spec.MinAvailable)
+		})
+	}
+}
+
+func TestSentinelPDBUsesSentinelReplicaCount(t *testing.T) {
+	tests := []struct {
+		name             string
+		redisReplicas    int32
+		sentinelReplicas int32
+		expectedMin      intstr.IntOrString
+	}{
+		{
+			name:             "Sentinel replicas > 2 gives minAvailable 2",
+			redisReplicas:    1, // should not affect Sentinel PDB
+			sentinelReplicas: 3,
+			expectedMin:      intstr.FromInt(2),
+		},
+		{
+			name:             "Sentinel replicas <= 2 gives minAvailable 1",
+			redisReplicas:    5, // should not affect Sentinel PDB
+			sentinelReplicas: 2,
+			expectedMin:      intstr.FromInt(1),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+			rf := generateRF()
+			rf.Spec.Redis.Replicas = test.redisReplicas
+			rf.Spec.Sentinel.Replicas = test.sentinelReplicas
+
+			var gotPDB *policyv1.PodDisruptionBudget
+			ms := &mK8SService.Services{}
+			ms.On("CreateOrUpdatePodDisruptionBudget", namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
+				gotPDB = args.Get(1).(*policyv1.PodDisruptionBudget)
+			}).Return(nil)
+			ms.On("CreateOrUpdateDeployment", namespace, mock.Anything).Once().Return(nil)
+
+			client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+			err := client.EnsureSentinelDeployment(rf, nil, []metav1.OwnerReference{})
+
+			assert.NoError(err)
+			assert.NotNil(gotPDB)
+			assert.Equal(test.expectedMin, *gotPDB.Spec.MinAvailable)
+		})
+	}
+}
+
+func TestPDBSelectorContainsOnlyStableLabels(t *testing.T) {
+	// Extra metadata labels that should appear on the PDB resource but NOT in the selector.
+	extraLabels := map[string]string{
+		"team":        "infra",
+		"environment": "production",
+	}
+	stableKeys := []string{
+		"app.kubernetes.io/name",
+		"app.kubernetes.io/component",
+		"app.kubernetes.io/part-of",
+	}
+
+	t.Run("Redis PDB selector is stable", func(t *testing.T) {
+		assert := assert.New(t)
+		rf := generateRF()
+
+		var gotPDB *policyv1.PodDisruptionBudget
+		ms := &mK8SService.Services{}
+		ms.On("CreateOrUpdatePodDisruptionBudget", namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
+			gotPDB = args.Get(1).(*policyv1.PodDisruptionBudget)
+		}).Return(nil)
+		ms.On("CreateOrUpdateStatefulSet", namespace, mock.Anything).Once().Return(nil)
+
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		err := client.EnsureRedisStatefulset(rf, extraLabels, []metav1.OwnerReference{})
+
+		assert.NoError(err)
+		assert.NotNil(gotPDB)
+		selector := gotPDB.Spec.Selector.MatchLabels
+		// Extra propagated labels must not appear in the selector.
+		for k := range extraLabels {
+			assert.NotContains(selector, k, "extra label %q must not appear in PDB selector", k)
+		}
+		// Stable workload labels must be present.
+		for _, k := range stableKeys {
+			assert.Contains(selector, k, "stable label %q must be present in PDB selector", k)
+		}
+		// The selector must contain only the stable keys.
+		assert.Len(selector, len(stableKeys))
+	})
+
+	t.Run("Sentinel PDB selector is stable", func(t *testing.T) {
+		assert := assert.New(t)
+		rf := generateRF()
+
+		var gotPDB *policyv1.PodDisruptionBudget
+		ms := &mK8SService.Services{}
+		ms.On("CreateOrUpdatePodDisruptionBudget", namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
+			gotPDB = args.Get(1).(*policyv1.PodDisruptionBudget)
+		}).Return(nil)
+		ms.On("CreateOrUpdateDeployment", namespace, mock.Anything).Once().Return(nil)
+
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		err := client.EnsureSentinelDeployment(rf, extraLabels, []metav1.OwnerReference{})
+
+		assert.NoError(err)
+		assert.NotNil(gotPDB)
+		selector := gotPDB.Spec.Selector.MatchLabels
+		for k := range extraLabels {
+			assert.NotContains(selector, k, "extra label %q must not appear in PDB selector", k)
+		}
+		for _, k := range stableKeys {
+			assert.Contains(selector, k, "stable label %q must be present in PDB selector", k)
+		}
+		assert.Len(selector, len(stableKeys))
+	})
 }


### PR DESCRIPTION
- Sentinel PDB minAvailable is derived from Sentinel replica count; Redis PDB uses Redis replica count. Previously both used Redis replicas.
- PDB spec.selector.matchLabels now contains only the stable workload selector labels (app.kubernetes.io/{name,component,part-of}), not the full propagated metadata label set, eliminating immutable-selector risk.
- Add failing tests first (TDD): replica-count isolation for Redis and Sentinel PDBs, and selector-stability test for both components.