### PR TITLE
Fix/partial failover success reporting

### DIFF
--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -10,6 +10,7 @@ import (
 
 	redisfailoverv1 "github.com/saremox/redis-operator/api/redisfailover/v1"
 	"github.com/saremox/redis-operator/metrics"
+	rfservice "github.com/saremox/redis-operator/operator/redisfailover/service"
 )
 
 // UpdateRedisesPods if the running version of pods is equal to the statefulset one
@@ -365,9 +366,13 @@ func (r *RedisFailoverHandler) checkAndHealOperatorManagedMode(rf *redisfailover
 			err = r.rfHealer.PromoteBestReplica(bestReplica.IP, rf)
 			setRedisCheckerMetrics(r.mClient, "redis", rf.Namespace, rf.Name, metrics.NO_MASTER, metrics.NOT_APPLICABLE, err)
 			if err != nil {
+				msg := "failed to promote replica"
+				if errors.Is(err, rfservice.ErrPartialReconciliation) {
+					msg = "failover incomplete: replica reconfiguration failed"
+				}
 				rf.Status = redisfailoverv1.RedisFailoverStatus{
 					State:   redisfailoverv1.NotHealthyState,
-					Message: "failover incomplete: replica reconfiguration failed",
+					Message: msg,
 				}
 				return err
 			}
@@ -403,9 +408,13 @@ func (r *RedisFailoverHandler) checkAndHealOperatorManagedMode(rf *redisfailover
 
 			err = r.rfHealer.PromoteBestReplica(bestReplica.IP, rf)
 			if err != nil {
+				msg := "failover failed"
+				if errors.Is(err, rfservice.ErrPartialReconciliation) {
+					msg = "failover incomplete: replica reconfiguration failed"
+				}
 				rf.Status = redisfailoverv1.RedisFailoverStatus{
 					State:   redisfailoverv1.NotHealthyState,
-					Message: "failover incomplete: replica reconfiguration failed",
+					Message: msg,
 				}
 				return err
 			}

--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -367,7 +367,7 @@ func (r *RedisFailoverHandler) checkAndHealOperatorManagedMode(rf *redisfailover
 			if err != nil {
 				rf.Status = redisfailoverv1.RedisFailoverStatus{
 					State:   redisfailoverv1.NotHealthyState,
-					Message: "failed to promote replica",
+					Message: "failover incomplete: replica reconfiguration failed",
 				}
 				return err
 			}
@@ -405,7 +405,7 @@ func (r *RedisFailoverHandler) checkAndHealOperatorManagedMode(rf *redisfailover
 			if err != nil {
 				rf.Status = redisfailoverv1.RedisFailoverStatus{
 					State:   redisfailoverv1.NotHealthyState,
-					Message: "failover failed",
+					Message: "failover incomplete: replica reconfiguration failed",
 				}
 				return err
 			}

--- a/operator/redisfailover/service/heal.go
+++ b/operator/redisfailover/service/heal.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"sort"
 	"strconv"
 
@@ -11,6 +12,12 @@ import (
 	"github.com/saremox/redis-operator/service/redis"
 	v1 "k8s.io/api/core/v1"
 )
+
+// ErrPartialReconciliation is returned by PromoteBestReplica when the new
+// master was promoted successfully but one or more replicas could not be
+// repointed or relabelled.  The caller should treat this as an incomplete
+// failover, not a total failure.
+var ErrPartialReconciliation = errors.New("promotion succeeded but replica reconciliation incomplete")
 
 // RedisFailoverHeal defines the interface able to fix the problems on the redis failovers
 type RedisFailoverHeal interface {
@@ -327,8 +334,8 @@ func (r *RedisFailoverHealer) PromoteBestReplica(newMasterIP string, rf *redisfa
 		}
 	}
 
-	if err := errors.Join(reconcileErrs...); err != nil {
-		return err
+	if joinedErr := errors.Join(reconcileErrs...); joinedErr != nil {
+		return fmt.Errorf("%w: %w", ErrPartialReconciliation, joinedErr)
 	}
 
 	r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).

--- a/operator/redisfailover/service/heal.go
+++ b/operator/redisfailover/service/heal.go
@@ -301,6 +301,7 @@ func (r *RedisFailoverHealer) PromoteBestReplica(newMasterIP string, rf *redisfa
 	r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).
 		Infof("Reconfiguring replicas to use new master %s", newMasterIP)
 
+	var reconcileErrs []error
 	for _, rp := range rps.Items {
 		if rp.Status.PodIP == newMasterIP {
 			continue
@@ -315,15 +316,19 @@ func (r *RedisFailoverHealer) PromoteBestReplica(newMasterIP string, rf *redisfa
 		if err := r.redisClient.MakeSlaveOfWithPort(rp.Status.PodIP, newMasterIP, port, password); err != nil {
 			r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).
 				Errorf("Failed to make %s slave of %s: %v", rp.Status.PodIP, newMasterIP, err)
-			// Continue with other replicas even if one fails
+			reconcileErrs = append(reconcileErrs, err)
 			continue
 		}
 
 		if err := r.setSlaveLabelIfNecessary(rf.Namespace, rp); err != nil {
 			r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).
 				Errorf("Failed to set slave label on pod %s: %v", rp.Name, err)
-			// Continue with other replicas even if label update fails
+			reconcileErrs = append(reconcileErrs, err)
 		}
+	}
+
+	if err := errors.Join(reconcileErrs...); err != nil {
+		return err
 	}
 
 	r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).

--- a/operator/redisfailover/service/heal_test.go
+++ b/operator/redisfailover/service/heal_test.go
@@ -351,6 +351,133 @@ func TestSetExternalMasterOnAll(t *testing.T) {
 	}
 }
 
+func TestPromoteBestReplicaSuccess(t *testing.T) {
+	assert := assert.New(t)
+	rf := generateRF()
+
+	newMasterIP := "1.1.1.1"
+	replicaIP := "2.2.2.2"
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-master"},
+				Status: corev1.PodStatus{
+					PodIP: newMasterIP,
+					Phase: corev1.PodRunning,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-replica"},
+				Status: corev1.PodStatus{
+					PodIP: replicaIP,
+					Phase: corev1.PodRunning,
+				},
+			},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
+
+	mr := &mRedisService.Client{}
+	mr.On("MakeMaster", newMasterIP, "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", replicaIP, newMasterIP, "0", "").Once().Return(nil)
+
+	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
+
+	err := healer.PromoteBestReplica(newMasterIP, rf)
+	assert.NoError(err)
+	ms.AssertExpectations(t)
+	mr.AssertExpectations(t)
+}
+
+func TestPromoteBestReplicaReplicaRepointerFails(t *testing.T) {
+	assert := assert.New(t)
+	rf := generateRF()
+
+	newMasterIP := "1.1.1.1"
+	replicaIP := "2.2.2.2"
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-master"},
+				Status: corev1.PodStatus{
+					PodIP: newMasterIP,
+					Phase: corev1.PodRunning,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-replica"},
+				Status: corev1.PodStatus{
+					PodIP: replicaIP,
+					Phase: corev1.PodRunning,
+				},
+			},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	ms.On("UpdatePodLabels", namespace, "pod-master", mock.Anything).Return(nil)
+
+	mr := &mRedisService.Client{}
+	mr.On("MakeMaster", newMasterIP, "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", replicaIP, newMasterIP, "0", "").Once().Return(errors.New("replica repoint failed"))
+
+	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
+
+	err := healer.PromoteBestReplica(newMasterIP, rf)
+	assert.Error(err, "partial failover should not be reported as success")
+	ms.AssertExpectations(t)
+	mr.AssertExpectations(t)
+}
+
+func TestPromoteBestReplicaLabelUpdateFails(t *testing.T) {
+	assert := assert.New(t)
+	rf := generateRF()
+
+	newMasterIP := "1.1.1.1"
+	replicaIP := "2.2.2.2"
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-master"},
+				Status: corev1.PodStatus{
+					PodIP: newMasterIP,
+					Phase: corev1.PodRunning,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-replica"},
+				Status: corev1.PodStatus{
+					PodIP: replicaIP,
+					Phase: corev1.PodRunning,
+				},
+			},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	ms.On("UpdatePodLabels", namespace, "pod-master", mock.Anything).Return(nil)
+	ms.On("UpdatePodLabels", namespace, "pod-replica", mock.Anything).Return(errors.New("label update failed"))
+
+	mr := &mRedisService.Client{}
+	mr.On("MakeMaster", newMasterIP, "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", replicaIP, newMasterIP, "0", "").Once().Return(nil)
+
+	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
+
+	err := healer.PromoteBestReplica(newMasterIP, rf)
+	assert.Error(err, "label update failure should not be reported as success")
+	ms.AssertExpectations(t)
+	mr.AssertExpectations(t)
+}
+
 func TestNewSentinelMonitor(t *testing.T) {
 	tests := []struct {
 		name                string

--- a/operator/redisfailover/service/heal_test.go
+++ b/operator/redisfailover/service/heal_test.go
@@ -431,6 +431,7 @@ func TestPromoteBestReplicaReplicaRepointerFails(t *testing.T) {
 
 	err := healer.PromoteBestReplica(newMasterIP, rf)
 	assert.Error(err, "partial failover should not be reported as success")
+	assert.True(errors.Is(err, rfservice.ErrPartialReconciliation), "replica repoint failure should be wrapped as ErrPartialReconciliation")
 	ms.AssertExpectations(t)
 	mr.AssertExpectations(t)
 }
@@ -474,6 +475,26 @@ func TestPromoteBestReplicaLabelUpdateFails(t *testing.T) {
 
 	err := healer.PromoteBestReplica(newMasterIP, rf)
 	assert.Error(err, "label update failure should not be reported as success")
+	assert.True(errors.Is(err, rfservice.ErrPartialReconciliation), "slave label update failure should be wrapped as ErrPartialReconciliation")
+	ms.AssertExpectations(t)
+	mr.AssertExpectations(t)
+}
+
+func TestPromoteBestReplicaMakeMasterFails(t *testing.T) {
+	assert := assert.New(t)
+	rf := generateRF()
+
+	newMasterIP := "1.1.1.1"
+
+	ms := &mK8SService.Services{}
+	mr := &mRedisService.Client{}
+	mr.On("MakeMaster", newMasterIP, "0", "").Once().Return(errors.New("promotion failed"))
+
+	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
+
+	err := healer.PromoteBestReplica(newMasterIP, rf)
+	assert.Error(err, "MakeMaster failure should return an error")
+	assert.False(errors.Is(err, rfservice.ErrPartialReconciliation), "full promotion failure should not be wrapped as ErrPartialReconciliation")
 	ms.AssertExpectations(t)
 	mr.AssertExpectations(t)
 }


### PR DESCRIPTION
This pull request introduces improved error handling for Redis failover operations, specifically distinguishing between partial and total failover failures. It also adds comprehensive unit tests to validate these changes. The most important changes are grouped below:

### Error handling improvements

* Added a new error type, `ErrPartialReconciliation`, to indicate cases where the master promotion succeeds but some replicas fail to be repointed or relabelled, allowing the operator to treat these as incomplete failovers rather than total failures. (`operator/redisfailover/service/heal.go`)
* Updated the `PromoteBestReplica` method to collect errors from replica repointing and label updates, and to return `ErrPartialReconciliation` when any such errors occur. (`operator/redisfailover/service/heal.go`) [[1]](diffhunk://#diff-39162712263a5b4f68d57c228b922ea4387b31fbece53dffd2d7bf401fae3720R311) [[2]](diffhunk://#diff-39162712263a5b4f68d57c228b922ea4387b31fbece53dffd2d7bf401fae3720L318-R338)
* Modified the failover status messaging in `RedisFailoverHandler` to report "failover incomplete: replica reconfiguration failed" when partial reconciliation occurs, improving clarity in operator logs and status. (`operator/redisfailover/checker.go`) [[1]](diffhunk://#diff-a84121490c9661e1c575f30fe43318d4144a03257311cabeb9b07633834cd447R369-R375) [[2]](diffhunk://#diff-a84121490c9661e1c575f30fe43318d4144a03257311cabeb9b07633834cd447R411-R417)

### Testing enhancements

* Added unit tests for `PromoteBestReplica` to verify correct error handling for successful promotion, replica repoint failures, label update failures, and master promotion failures. (`operator/redisfailover/service/heal_test.go`)

### Dependency updates

* Imported the new `rfservice` package in `checker.go` to access the `ErrPartialReconciliation` error type. (`operator/redisfailover/checker.go`)
* Added `fmt` to imports in `heal.go` for improved error formatting. (`operator/redisfailover/service/heal.go`)

These changes make failover operations more robust and transparent, ensuring that partial failures are properly reported and tested.