### PR TITLE
Add validation for Redis command rename injection attacks

### DIFF
--- a/api/redisfailover/v1/validate.go
+++ b/api/redisfailover/v1/validate.go
@@ -3,6 +3,7 @@ package v1
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 )
 
@@ -10,10 +11,28 @@ const (
 	maxNameLength = 48
 )
 
+// validCommandRenamePattern restricts rename-command "from"/"to" values to
+// safe, non-empty Redis command name characters. This prevents the quotes,
+// spaces and newlines used in redisConfigTemplate's
+// `rename-command "{{.From}}" "{{.To}}"` line from being broken out of,
+// which would otherwise let a crafted CustomCommandRenames value inject
+// arbitrary directives into redis.conf.
+var validCommandRenamePattern = regexp.MustCompile(`^[A-Za-z_]+$`)
+
 // Validate set the values by default if not defined and checks if the values given are valid
 func (r *RedisFailover) Validate() error {
 	if len(r.Name) > maxNameLength {
 		return fmt.Errorf("name length can't be higher than %d", maxNameLength)
+	}
+
+	for _, rename := range r.Spec.Redis.CustomCommandRenames {
+		if !validCommandRenamePattern.MatchString(rename.From) {
+			return fmt.Errorf("customCommandRenames: invalid \"from\" command name %q, must match %s", rename.From, validCommandRenamePattern.String())
+		}
+		// "to" may be empty to disable the command entirely.
+		if rename.To != "" && !validCommandRenamePattern.MatchString(rename.To) {
+			return fmt.Errorf("customCommandRenames: invalid \"to\" command name %q, must match %s", rename.To, validCommandRenamePattern.String())
+		}
 	}
 
 	if r.Bootstrapping() {

--- a/api/redisfailover/v1/validate_test.go
+++ b/api/redisfailover/v1/validate_test.go
@@ -14,6 +14,7 @@ func TestValidate(t *testing.T) {
 		rfBootstrapNode        *BootstrapSettings
 		rfRedisCustomConfig    []string
 		rfSentinelCustomConfig []string
+		rfCommandRenames       []RedisCommandRename
 		expectedError          string
 		expectedBootstrapNode  *BootstrapSettings
 	}{
@@ -65,6 +66,23 @@ func TestValidate(t *testing.T) {
 			rfBootstrapNode:       &BootstrapSettings{Host: "127.0.0.1"},
 			expectedBootstrapNode: &BootstrapSettings{Host: "127.0.0.1", Port: "6379"},
 		},
+		{
+			name:             "Allows valid command renames, including disabling a command",
+			rfName:           "test",
+			rfCommandRenames: []RedisCommandRename{{From: "CONFIG", To: "MYCONFIG"}, {From: "FLUSHALL", To: ""}},
+		},
+		{
+			name:             "Rejects command rename injection via quotes in from",
+			rfName:           "test",
+			rfCommandRenames: []RedisCommandRename{{From: `CONFIG"` + "\n" + `slave-read-only no` + "\n" + `rename-command "FLUSHALL`, To: `""`}},
+			expectedError:    `customCommandRenames: invalid "from" command name "CONFIG\"\nslave-read-only no\nrename-command \"FLUSHALL", must match ^[A-Za-z_]+$`,
+		},
+		{
+			name:             "Rejects command rename injection via quotes in to",
+			rfName:           "test",
+			rfCommandRenames: []RedisCommandRename{{From: "CONFIG", To: `" shutdown nosave #`}},
+			expectedError:    `customCommandRenames: invalid "to" command name "\" shutdown nosave #", must match ^[A-Za-z_]+$`,
+		},
 	}
 
 	for _, test := range tests {
@@ -73,6 +91,7 @@ func TestValidate(t *testing.T) {
 			rf := generateRedisFailover(test.rfName, test.rfBootstrapNode)
 			rf.Spec.Redis.CustomConfig = test.rfRedisCustomConfig
 			rf.Spec.Sentinel.CustomConfig = test.rfSentinelCustomConfig
+			rf.Spec.Redis.CustomCommandRenames = test.rfCommandRenames
 
 			err := rf.Validate()
 
@@ -108,7 +127,8 @@ func TestValidate(t *testing.T) {
 							Exporter: Exporter{
 								Image: defaultExporterImage,
 							},
-							CustomConfig: expectedRedisCustomConfig,
+							CustomConfig:         expectedRedisCustomConfig,
+							CustomCommandRenames: test.rfCommandRenames,
 						},
 						Sentinel: SentinelSettings{
 							Image:        defaultImage,


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Add validation for `CustomCommandRenames` in Redis failover specs to prevent injection attacks through the `rename-command` configuration directive
- Implement regex pattern matching (`^[A-Za-z_]+$`) to restrict "from" and "to" command names to safe characters only, preventing quotes, spaces, and newlines from breaking out of the redis.conf template
- Allow empty "to" values to support disabling commands entirely via `rename-command "COMMAND" ""`
- Add comprehensive test cases covering valid renames, injection attempts via quotes in "from" field, and injection attempts via quotes in "to" field

The validation prevents a security vulnerability where crafted `CustomCommandRenames` values could inject arbitrary Redis configuration directives by breaking out of the `rename-command "{{.From}}" "{{.To}}"` template line in redis.conf.

https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE