### PR TITLE
Guard against replicas attaching to another RedisFailover's master

### DIFF
--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -264,7 +264,19 @@ func (r *RedisFailoverHandler) CheckAndHeal(rf *redisfailoverv1.RedisFailover) e
 	setRedisCheckerMetrics(r.mClient, "redis", rf.Namespace, rf.Name, metrics.SLAVE_WRONG_MASTER, metrics.NOT_APPLICABLE, err)
 	if err != nil {
 		r.logger.WithField("redisfailover", rf.ObjectMeta.Name).WithField("namespace", rf.ObjectMeta.Namespace).Warningf("Slave not associated to master: %s", err.Error())
-		if err = r.rfHealer.SetMasterOnAll(master, rf); err != nil {
+		// Re-resolve master right before acting on it: `master` was captured
+		// above and pod churn since then could have moved it. Narrowing this
+		// window reduces how often SetMasterOnAll's own ownership check has
+		// to reject a stale IP and wait for the next reconcile.
+		freshMaster, ferr := r.rfChecker.GetMasterIP(rf)
+		if ferr != nil {
+			rf.Status = redisfailoverv1.RedisFailoverStatus{
+				State:   redisfailoverv1.NotHealthyState,
+				Message: "unable to re-verify master IP",
+			}
+			return ferr
+		}
+		if err = r.rfHealer.SetMasterOnAll(freshMaster, rf); err != nil {
 			rf.Status = redisfailoverv1.RedisFailoverStatus{
 				State: redisfailoverv1.NotHealthyState,
 			}
@@ -301,12 +313,29 @@ func (r *RedisFailoverHandler) CheckAndHeal(rf *redisfailoverv1.RedisFailover) e
 	}
 
 	port := getRedisPort(rf.Spec.Redis.Port)
+	// `master` may be stale by now (resolved above, before applyRedisCustomConfig
+	// and UpdateRedisesPods ran). Re-resolve it lazily, once, only if a sentinel
+	// actually needs fixing, and reuse that fresh value for the rest of the loop.
+	sentinelMonitorMaster := master
+	masterRefreshed := false
 	for _, sip := range sentinels {
 		err = r.rfChecker.CheckSentinelMonitor(sip, master, port)
 		setRedisCheckerMetrics(r.mClient, "sentinel", rf.Namespace, rf.Name, metrics.SENTINEL_WRONG_MASTER, sip, err)
 		if err != nil {
 			r.logger.WithField("redisfailover", rf.ObjectMeta.Name).WithField("namespace", rf.ObjectMeta.Namespace).Warningf("Fixing sentinel not monitoring expected master: %s", err.Error())
-			if err := r.rfHealer.NewSentinelMonitor(sip, master, rf); err != nil {
+			if !masterRefreshed {
+				freshMaster, ferr := r.rfChecker.GetMasterIP(rf)
+				if ferr != nil {
+					rf.Status = redisfailoverv1.RedisFailoverStatus{
+						State:   redisfailoverv1.NotHealthyState,
+						Message: "unable to re-verify master IP",
+					}
+					return ferr
+				}
+				sentinelMonitorMaster = freshMaster
+				masterRefreshed = true
+			}
+			if err := r.rfHealer.NewSentinelMonitor(sip, sentinelMonitorMaster, rf); err != nil {
 				rf.Status = redisfailoverv1.RedisFailoverStatus{
 					State: redisfailoverv1.NotHealthyState,
 				}

--- a/operator/redisfailover/checker_test.go
+++ b/operator/redisfailover/checker_test.go
@@ -362,7 +362,19 @@ func TestCheckAndHeal(t *testing.T) {
 					expErr = true
 				}
 				if !expErr && continueTests {
-					mrfc.On("GetMasterIP", rf).Twice().Return(master, nil)
+					// checker.go re-resolves GetMasterIP right before SetMasterOnAll
+					// (when slaves are wrong) and right before NewSentinelMonitor
+					// (when a sentinel isn't monitoring the right master), on top
+					// of the base call in checkAndHeal and the one inside
+					// UpdateRedisesPods.
+					getMasterIPCalls := 2
+					if !test.slavesOK {
+						getMasterIPCalls++
+					}
+					if !test.sentinelMonitorOK {
+						getMasterIPCalls++
+					}
+					mrfc.On("GetMasterIP", rf).Times(getMasterIPCalls).Return(master, nil)
 					if test.slavesOK {
 						mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(nil)
 					} else {

--- a/operator/redisfailover/service/heal.go
+++ b/operator/redisfailover/service/heal.go
@@ -150,10 +150,35 @@ func (r *RedisFailoverHealer) SetOldestAsMaster(rf *redisfailoverv1.RedisFailove
 	}
 }
 
+// podIPBelongsTo reports whether ip is currently the PodIP of one of the
+// given pods. GetStatefulSetPods scopes its List() call by namespace and by
+// the owning StatefulSet's own label selector, so a freshly-fetched pods
+// list can only ever contain this RedisFailover's own pods: Kubernetes never
+// hands the same live IP to two Running pods at once. Checking membership
+// against a list fetched right before a mutating call therefore closes the
+// window where a master/replica IP resolved earlier in the reconcile could
+// since have been reassigned (e.g. after node churn) to an unrelated pod,
+// possibly belonging to a different RedisFailover in another namespace. See
+// https://github.com/spotahome/redis-operator/issues/698.
+func podIPBelongsTo(pods *v1.PodList, ip string) bool {
+	for _, pod := range pods.Items {
+		if pod.Status.PodIP == ip {
+			return true
+		}
+	}
+	return false
+}
+
 // SetMasterOnAll puts all redis nodes as a slave of a given master
 func (r *RedisFailoverHealer) SetMasterOnAll(masterIP string, rf *redisfailoverv1.RedisFailover) error {
 	ssp, err := r.k8sService.GetStatefulSetPods(rf.Namespace, GetRedisName(rf))
 	if err != nil {
+		return err
+	}
+
+	if !podIPBelongsTo(ssp, masterIP) {
+		err := fmt.Errorf("refusing to set master %s: it is not currently a pod of %s/%s, bailing out this round", masterIP, rf.Namespace, rf.Name)
+		r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).Error(err.Error())
 		return err
 	}
 
@@ -277,6 +302,21 @@ func (r *RedisFailoverHealer) PromoteBestReplica(newMasterIP string, rf *redisfa
 
 	port := getRedisPort(rf.Spec.Redis.Port)
 
+	// Fetch this RedisFailover's own pods fresh, immediately before acting on
+	// newMasterIP, and verify it's still one of them. This closes the race
+	// where newMasterIP was resolved earlier in the reconcile and has since
+	// been reassigned to an unrelated pod, possibly in a different
+	// namespace/RedisFailover. See https://github.com/spotahome/redis-operator/issues/698.
+	rps, err := r.k8sService.GetStatefulSetPods(rf.Namespace, GetRedisName(rf))
+	if err != nil {
+		return err
+	}
+	if !podIPBelongsTo(rps, newMasterIP) {
+		err := fmt.Errorf("refusing to promote %s: it is not currently a pod of %s/%s, bailing out this round", newMasterIP, rf.Namespace, rf.Name)
+		r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).Error(err.Error())
+		return err
+	}
+
 	// Step 1: Promote the selected replica to master
 	r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).
 		Infof("Promoting replica %s to master", newMasterIP)
@@ -288,11 +328,6 @@ func (r *RedisFailoverHealer) PromoteBestReplica(newMasterIP string, rf *redisfa
 	}
 
 	// Step 2: Update pod labels for the new master
-	rps, err := r.k8sService.GetStatefulSetPods(rf.Namespace, GetRedisName(rf))
-	if err != nil {
-		return err
-	}
-
 	for _, rp := range rps.Items {
 		if rp.Status.PodIP == newMasterIP {
 			if err := r.setMasterLabelIfNecessary(rf.Namespace, rp); err != nil {

--- a/operator/redisfailover/service/heal_test.go
+++ b/operator/redisfailover/service/heal_test.go
@@ -277,6 +277,34 @@ func TestSetMasterOnAll(t *testing.T) {
 	assert.NoError(err)
 }
 
+func TestSetMasterOnAllRejectsIPNotOwnedByRF(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+
+	// None of this RedisFailover's own pods have this IP: it could be a stale
+	// value resolved earlier in the reconcile that's since been reassigned to
+	// an unrelated pod, possibly in a different namespace/RedisFailover. See
+	// https://github.com/spotahome/redis-operator/issues/698.
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{Status: corev1.PodStatus{PodIP: "1.1.1.1"}},
+			{Status: corev1.PodStatus{PodIP: "2.2.2.2"}},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	mr := &mRedisService.Client{}
+
+	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
+
+	err := healer.SetMasterOnAll("9.9.9.9", rf)
+	assert.Error(err, "should refuse to act on an IP that isn't currently one of this RedisFailover's own pods")
+	ms.AssertExpectations(t)
+	mr.AssertExpectations(t) // no IsMaster/MakeSlaveOfWithPort calls should have happened
+}
+
 func TestSetExternalMasterOnAll(t *testing.T) {
 	tests := []struct {
 		name                  string
@@ -486,7 +514,20 @@ func TestPromoteBestReplicaMakeMasterFails(t *testing.T) {
 
 	newMasterIP := "1.1.1.1"
 
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-master"},
+				Status: corev1.PodStatus{
+					PodIP: newMasterIP,
+					Phase: corev1.PodRunning,
+				},
+			},
+		},
+	}
+
 	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", newMasterIP, "0", "").Once().Return(errors.New("promotion failed"))
 
@@ -497,6 +538,40 @@ func TestPromoteBestReplicaMakeMasterFails(t *testing.T) {
 	assert.False(errors.Is(err, rfservice.ErrPartialReconciliation), "full promotion failure should not be wrapped as ErrPartialReconciliation")
 	ms.AssertExpectations(t)
 	mr.AssertExpectations(t)
+}
+
+func TestPromoteBestReplicaRejectsIPNotOwnedByRF(t *testing.T) {
+	assert := assert.New(t)
+	rf := generateRF()
+
+	// newMasterIP isn't a pod of this RedisFailover: refuse to promote it
+	// rather than blindly issuing MakeMaster against a possibly-foreign
+	// instance. See https://github.com/spotahome/redis-operator/issues/698.
+	newMasterIP := "9.9.9.9"
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "pod-replica"},
+				Status: corev1.PodStatus{
+					PodIP: "2.2.2.2",
+					Phase: corev1.PodRunning,
+				},
+			},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	mr := &mRedisService.Client{}
+
+	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
+
+	err := healer.PromoteBestReplica(newMasterIP, rf)
+	assert.Error(err, "should refuse to promote an IP that isn't currently one of this RedisFailover's own pods")
+	assert.False(errors.Is(err, rfservice.ErrPartialReconciliation))
+	ms.AssertExpectations(t)
+	mr.AssertExpectations(t) // no MakeMaster call should have happened
 }
 
 func TestNewSentinelMonitor(t *testing.T) {


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Add `podIPBelongsTo` and use it in `SetMasterOnAll` and `PromoteBestReplica` to verify, immediately before issuing `REPLICAOF`/promoting a pod, that the target IP is still one of this RedisFailover's own pods (fetched fresh, scoped by namespace + the owning StatefulSet's own label selector).
- `PromoteBestReplica` now fetches its pod list before calling `MakeMaster` instead of after, so the same fresh list backs both the ownership check and the label-update step.
- `checkAndHeal` re-resolves the master IP immediately before calling `SetMasterOnAll` and before fixing up a sentinel's monitored target, narrowing the window between when the master was first resolved and when it's actually acted on.

### Why

Upstream issue [spotahome/redis-operator#698](https://github.com/spotahome/redis-operator/issues/698): a master/replica IP is resolved once during a reconcile and reused several K8s/Redis calls later. Kubernetes Pod IPs are cluster-wide, not namespace-scoped, so pod/node churn in that window can reassign the IP to an unrelated pod — possibly belonging to a *different* RedisFailover in another namespace — causing replicas to silently sync from (and be attached to) the wrong cluster's master.

### Design constraint: no behavior change on the healthy path

This fix is a pure safety net, not a change to how replication is configured:
- The ownership check only ever *rejects* an IP that would previously have been trusted blindly; on a healthy cluster the IP is always present in the freshly-fetched list, so every command sent to Redis is byte-for-byte identical to before.
- When it does reject a stale IP, it returns an error and defers to the next reconcile — the same "wait and retry" pattern already used elsewhere in this code (e.g. the existing `IsMaster` check in `SetMasterOnAll`).
- No CRD fields, config options, or CLI flags added or changed.

Considered and deliberately not included:
- A Redis-side identity marker (`CONFIG SET`) — not actually implementable; `CONFIG SET` only accepts predefined Redis parameters, not arbitrary custom keys. The alternatives (a real keyspace key, or repurposing a cosmetic parameter like `proc-title-template`) are both real behavior changes, and the pod-list check above is already an authoritative, race-free ownership proof under normal Kubernetes IPAM guarantees, so a marker adds no additional correctness.
- Switching `REPLICAOF`/`SENTINEL MONITOR` to per-pod DNS names instead of Pod IPs — the architecturally "cleaner" long-term fix, but a much larger behavior change (changes `INFO replication`'s `master_host` from an IP to a hostname, requires `sentinel resolve-hostnames`/`announce-hostnames` which isn't currently set, and adds a hard runtime dependency on cluster DNS). Out of scope for this fix given the no-behavior-change constraint.

### Testing
- Added `TestSetMasterOnAllRejectsIPNotOwnedByRF` and `TestPromoteBestReplicaRejectsIPNotOwnedByRF` covering the new guard directly.
- Updated existing `TestCheckAndHeal` and `TestPromoteBestReplicaMakeMasterFails` mock expectations for the reordered/added calls.
- `go build ./...`, `go test ./...`, `go vet ./...`, and `golangci-lint run ./operator/...` all pass clean.

https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_