### PR TITLE
Fix dev Dockerfile build failure with --build-arg uid=0

### DIFF
--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -23,10 +23,11 @@ RUN wget -c https://github.com/vektra/mockery/releases/download/v${MOCKERY_VERSI
 # Create user
 ARG uid=1000
 ARG gid=1000
-RUN addgroup -g $gid rf && \
-    adduser -D -u $uid -G rf rf && \
-    chown rf:rf -R /go
+RUN if ! getent passwd "$uid" > /dev/null 2>&1; then \
+      addgroup -g "$gid" rf && \
+      adduser -D -u "$uid" -G rf rf; \
+    fi && \
+    chown -R "$uid":"$gid" /go
 
-
-USER rf
+USER $uid
 WORKDIR /go/src/github.com/saremox/redis-operator


### PR DESCRIPTION
Fixes spotahome/redis-operator#708.

Changes proposed on the PR:
- Make the user-creation `RUN` step in `docker/development/Dockerfile` conditional on whether the requested `uid` already exists in `/etc/passwd` (checked via `getent passwd "$uid"`), instead of unconditionally running `adduser -D -u $uid -G rf rf`.
- Switch `chown` and `USER` to use the numeric `$uid`/`$gid` build args directly, so both work correctly whether or not the named `rf` user/group was actually created.
- No behavior change for the default `uid=1000` path: the `addgroup`/`adduser` branch still runs exactly as before.

### Root cause

`make build` / `make docker-build` passes `--build-arg uid=$(UID)` where `UID := $(shell id -u)` (Makefile lines 26 and 73). When `make` is invoked as root (e.g. in CI, or inside a root-run container), this becomes `--build-arg uid=0`. The Dockerfile then unconditionally ran:

```
adduser -D -u 0 -G rf rf
```

which fails because uid 0 is already taken by the `root` user shipped in the `golang:1.25-alpine` base image:

```
adduser: uid '0' in use
The command '/bin/sh -c addgroup -g $gid rf && adduser -D -u $uid -G rf rf...' returned a non-zero code: 1
```

### Diff

```diff
 # Create user
 ARG uid=1000
 ARG gid=1000
-RUN addgroup -g $gid rf && \
-    adduser -D -u $uid -G rf rf && \
-    chown rf:rf -R /go
+RUN if ! getent passwd "$uid" > /dev/null 2>&1; then \
+      addgroup -g "$gid" rf && \
+      adduser -D -u "$uid" -G rf rf; \
+    fi && \
+    chown -R "$uid":"$gid" /go
 
-
-USER rf
+USER $uid
 WORKDIR /go/src/github.com/saremox/redis-operator
```

### Validation

**Docker was not usable in the sandbox this PR was prepared in** — the `docker` CLI is present but there is no daemon socket (`dial unix /var/run/docker.sock: connect: no such file or directory`, confirmed via `docker info`). So I was **not able to run an actual `docker build`** for either the `uid=0` or default-`uid` case, and I am not claiming that a real image build succeeded.

Instead, as a proxy check I dry-ran the exact shell conditional that the `RUN` step now uses, directly on the sandbox host (which, like the Alpine image, has a working `getent` and `root` at uid 0):

```
$ sh -c 'if ! getent passwd 0 >/dev/null 2>&1; then echo would-create; else echo exists; fi'
exists
```

This confirms that for `uid=0` the new conditional correctly takes the "skip creation" branch (matching `getent passwd 0` finding the pre-existing `root` entry), which is exactly the case that previously made `adduser` fail. For the default `uid=1000` case (or any other uid not already present in the image's `/etc/passwd`), `getent passwd "$uid"` fails/returns nothing, so the `addgroup`/`adduser` branch still runs unchanged — this is unchanged logic from before, just now inside the `if`, so the existing default build path is unaffected.

**A maintainer with Docker available should still run the real builds before merging**, e.g. from repo root:
```
docker build --build-arg uid=0 --build-arg gid=0 -f docker/development/Dockerfile -t redis-operator-dev-test:uid0 .
docker build -f docker/development/Dockerfile -t redis-operator-dev-test:default .
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_