### PR TITLE
Fix aclfile customConfig silently not loading ACL users

### DIFF
--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -460,6 +460,7 @@ func (c *client) SetCustomRedisConfig(ip string, port string, configs []string, 
 		}
 	}(rClient)
 
+	needsACLLoad := false
 	for _, config := range configs {
 		param, value, err := c.getConfigParameters(config)
 		if err != nil {
@@ -473,7 +474,34 @@ func (c *client) SetCustomRedisConfig(ip string, port string, configs []string, 
 		if err := c.applyRedisConfig(param, value, rClient); err != nil {
 			return err
 		}
+		if strings.EqualFold(param, "aclfile") {
+			needsACLLoad = true
+		}
 	}
+	// `CONFIG SET aclfile <path>` only changes the path Redis will use for its ACL file,
+	// it does not read the file's contents into the running ACL table. An explicit
+	// `ACL LOAD` is required afterwards, otherwise the users defined in the file never
+	// actually get created.
+	if needsACLLoad {
+		if err := c.applyACLLoad(rClient); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *client) applyACLLoad(rClient *rediscli.Client) error {
+	cmd := rediscli.NewStatusCmd(context.TODO(), "ACL", "LOAD")
+	err := rClient.Process(context.TODO(), cmd)
+	if err != nil {
+		c.metricsRecorder.RecordRedisOperation(metrics.KIND_REDIS, strings.Split(rClient.Options().Addr, ":")[0], metrics.APPLY_REDIS_CONFIG, metrics.FAIL, getRedisError(err))
+		return err
+	}
+	if _, err := cmd.Result(); err != nil {
+		c.metricsRecorder.RecordRedisOperation(metrics.KIND_REDIS, strings.Split(rClient.Options().Addr, ":")[0], metrics.APPLY_REDIS_CONFIG, metrics.FAIL, getRedisError(err))
+		return err
+	}
+	c.metricsRecorder.RecordRedisOperation(metrics.KIND_REDIS, strings.Split(rClient.Options().Addr, ":")[0], metrics.APPLY_REDIS_CONFIG, metrics.SUCCESS, metrics.NOT_APPLICABLE)
 	return nil
 }
 


### PR DESCRIPTION
Fixes spotahome/redis-operator#693.

Changes proposed on the PR:
- Root cause: `SetCustomRedisConfig` in `service/redis/client.go` applies each `RedisFailover.Spec.Redis.CustomConfig` line with a plain `CONFIG SET`. For `aclfile <path>`, `CONFIG SET aclfile <path>` only changes the *path* Redis will use for its ACL file — it does not read the file's contents into the running ACL table, so the users defined in the mounted ACL file never actually get created (only the default and `pinger` users show up).
- Fix: `SetCustomRedisConfig` now tracks (case-insensitively via `strings.EqualFold`) whether any processed config line set `aclfile`. Once all config lines have been applied successfully, if that flag is set it issues an explicit `ACL LOAD` on the same Redis connection to parse the file and load its users, following the existing `SENTINEL` command pattern already used elsewhere in this file (`rediscli.NewStatusCmd` + `rClient.Process` + `cmd.Result()`, with the same `metrics.RecordRedisOperation`/`metrics.APPLY_REDIS_CONFIG` success/failure recording as `applyRedisConfig`).
- No changes to the `SetCustomRedisConfig` function signature or any of its callers; only `service/redis/client.go` was touched.
- Testing: `service/redis/client.go` currently has no unit-test harness (no `client_test.go`) — it's a thin wrapper over `github.com/go-redis/redis/v8`, exercised elsewhere via the mocked `redis.Client` interface (`mocks/service/redis/Client.go`) and via `test/integration/redisfailover/`, which requires a real cluster. Consistent with how the rest of this file is tested, no new test dependency (e.g. miniredis) was added for this fix; it is validated via `go build ./...`, `go vet ./...`, `go test ./...` (all pass), and `golangci-lint run ./service/...` (0 issues), plus code review.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_