### PR TITLE
Roll Redis pods when the auth Secret's password changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ spec:
 ```
 You need to set secretPath as the secret name which is created before.
 
+Rotating the password (updating the `password` key of that same Secret in place) is safe: the operator watches a checksum of the current password and rolls the Redis pods, one at a time, whenever it changes.
+
 ### Bootstrapping from pre-existing Redis Instance(s)
 If you are wanting to migrate off of a pre-existing Redis instance, you can provide a `bootstrapNode` to your `RedisFailover` resource spec.
 

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -105,8 +105,14 @@ func (r *RedisFailoverKubeClient) EnsureRedisStatefulset(rf *redisfailoverv1.Red
 			return err
 		}
 	}
-	ss := generateRedisStatefulSet(rf, labels, ownerRefs)
-	err := r.K8SService.CreateOrUpdateStatefulSet(rf.Namespace, ss)
+
+	password, err := k8s.GetRedisPassword(r.K8SService, rf)
+	if err != nil {
+		return err
+	}
+
+	ss := generateRedisStatefulSet(rf, labels, ownerRefs, password)
+	err = r.K8SService.CreateOrUpdateStatefulSet(rf.Namespace, ss)
 
 	r.setEnsureOperationMetrics(ss.Namespace, ss.Name, "StatefulSet", rf.Name, err)
 	return err

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -34,3 +34,14 @@ const (
 	redisRoleLabelMaster = "master"
 	redisRoleLabelSlave  = "slave"
 )
+
+// redisAuthSecretChecksumAnnotation is set on the Redis StatefulSet's pod
+// template to a checksum of the current auth password. Kubernetes doesn't
+// restart running pods when a Secret's data changes in place (only the
+// mounted file content is updated), so without this the operator would keep
+// using the new password from the Secret against pods still running with the
+// old one loaded in memory, and would never detect that those pods need to
+// be replaced. Changing the annotation's value changes the StatefulSet's pod
+// template hash, which the existing revision-based staleness check in
+// UpdateRedisesPods already uses to roll pods one at a time.
+const redisAuthSecretChecksumAnnotation = "redisfailovers.databases.spotahome.com/secret-checksum"

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 	"text/template"
@@ -333,7 +334,7 @@ esac`, port)
 	}
 }
 
-func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *appsv1.StatefulSet {
+func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference, password string) *appsv1.StatefulSet {
 	name := GetRedisName(rf)
 	namespace := rf.Namespace
 
@@ -341,6 +342,11 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 	selectorLabels := generateSelectorLabels(redisRoleName, rf.Name)
 	labels = util.MergeLabels(labels, selectorLabels)
 	labels = util.MergeLabels(labels, generateRedisDefaultRoleLabel())
+
+	authSecretChecksum := fmt.Sprintf("%x", sha256.Sum256([]byte(password)))
+	podAnnotations := util.MergeAnnotations(rf.Spec.Redis.PodAnnotations, map[string]string{
+		redisAuthSecretChecksumAnnotation: authSecretChecksum,
+	})
 
 	volumeMounts := getRedisVolumeMounts(rf)
 	volumes := getRedisVolumes(rf)
@@ -367,7 +373,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      labels,
-					Annotations: rf.Spec.Redis.PodAnnotations,
+					Annotations: podAnnotations,
 				},
 				Spec: corev1.PodSpec{
 					Affinity:                      getAffinity(rf.Spec.Redis.Affinity, labels),

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"crypto/hmac"
 	"crypto/sha256"
 	"fmt"
 	"strings"
@@ -343,7 +344,9 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 	labels = util.MergeLabels(labels, selectorLabels)
 	labels = util.MergeLabels(labels, generateRedisDefaultRoleLabel())
 
-	authSecretChecksum := fmt.Sprintf("%x", sha256.Sum256([]byte(password)))
+	mac := hmac.New(sha256.New, []byte(rf.Namespace+"/"+rf.Name))
+	_, _ = mac.Write([]byte(password))
+	authSecretChecksum := fmt.Sprintf("%x", mac.Sum(nil))
 	podAnnotations := util.MergeAnnotations(rf.Spec.Redis.PodAnnotations, map[string]string{
 		redisAuthSecretChecksumAnnotation: authSecretChecksum,
 	})

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -691,9 +691,62 @@ func TestRedisStatefulSetPodAnnotations(t *testing.T) {
 		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
 		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 
+		// The Redis StatefulSet's pod template always carries an auth-secret
+		// checksum annotation (see redisAuthSecretChecksumAnnotation) so that
+		// pods roll when the referenced Secret's password value changes.
+		// Assert its presence/format separately, then compare the rest.
+		assert.Contains(gotPodAnnotations, "redisfailovers.databases.spotahome.com/secret-checksum")
+		assert.Len(gotPodAnnotations["redisfailovers.databases.spotahome.com/secret-checksum"], 64)
+		delete(gotPodAnnotations, "redisfailovers.databases.spotahome.com/secret-checksum")
+		if len(gotPodAnnotations) == 0 {
+			gotPodAnnotations = nil
+		}
+
 		assert.Equal(test.expectedPodAnnotations, gotPodAnnotations)
 		assert.NoError(err)
 	}
+}
+
+// TestRedisStatefulSetAuthSecretChecksumChangesWithPassword is a regression test
+// for spotahome/redis-operator#658: rotating the auth Secret's password value
+// (same Secret name, new data) must change the Redis pod template's checksum
+// annotation, so the operator's existing revision-based rolling update logic
+// actually replaces the running pods instead of leaving them stuck on the old
+// password while the operator itself starts using the new one.
+func TestRedisStatefulSetAuthSecretChecksumChangesWithPassword(t *testing.T) {
+	assert := assert.New(t)
+
+	generateSS := func(password string) map[string]string {
+		rf := generateRF()
+		rf.Spec.Auth.SecretPath = "redis-secret"
+
+		var gotAnnotations map[string]string
+		ms := &mK8SService.Services{}
+		ms.On("CreateOrUpdatePodDisruptionBudget", namespace, mock.Anything).Once().Return(nil, nil)
+		ms.On("GetSecret", namespace, "redis-secret").Once().Return(&corev1.Secret{
+			Data: map[string][]byte{"password": []byte(password)},
+		}, nil)
+		ms.On("CreateOrUpdateStatefulSet", namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
+			ss := args.Get(1).(*appsv1.StatefulSet)
+			gotAnnotations = ss.Spec.Template.ObjectMeta.Annotations
+		}).Return(nil)
+
+		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
+		err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
+		assert.NoError(err)
+
+		return gotAnnotations
+	}
+
+	const checksumKey = "redisfailovers.databases.spotahome.com/secret-checksum"
+
+	annotationsV1 := generateSS("password-v1")
+	annotationsV1Again := generateSS("password-v1")
+	annotationsV2 := generateSS("password-v2")
+
+	assert.NotEmpty(annotationsV1[checksumKey])
+	assert.Equal(annotationsV1[checksumKey], annotationsV1Again[checksumKey], "same password must produce the same checksum")
+	assert.NotEqual(annotationsV1[checksumKey], annotationsV2[checksumKey], "a rotated password must produce a different checksum, so the pod template (and its revision hash) changes")
 }
 
 func TestSentinelDeploymentPodAnnotations(t *testing.T) {
@@ -2242,6 +2295,11 @@ func TestRedisEnv(t *testing.T) {
 
 		ms := &mK8SService.Services{}
 		ms.On("CreateOrUpdatePodDisruptionBudget", namespace, mock.Anything).Once().Return(nil, nil)
+		if test.auth != "" {
+			ms.On("GetSecret", namespace, test.auth).Once().Return(&corev1.Secret{
+				Data: map[string][]byte{"password": []byte("s3cr3t")},
+			}, nil)
+		}
 		ms.On("CreateOrUpdateStatefulSet", namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
 			s := args.Get(1).(*appsv1.StatefulSet)
 			env = s.Spec.Template.Spec.Containers[0].Env


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- `generateRedisStatefulSet` now stamps the Redis pod template with a `redisfailovers.databases.spotahome.com/secret-checksum` annotation, a sha256 checksum of the current auth password (fetched the same way `EnsureRedisConfigMap` already does).
- `EnsureRedisStatefulset` fetches the password and passes it through.
- New regression test `TestRedisStatefulSetAuthSecretChecksumChangesWithPassword` asserts the checksum is stable for an unchanged password and changes when the password rotates.
- Updated `TestRedisStatefulSetPodAnnotations` and `TestRedisEnv` for the new always-present annotation / password fetch.
- One-line README note under the auth section.

### Why

Upstream issue [spotahome/redis-operator#658](https://github.com/spotahome/redis-operator/issues/658): rotating the password *inside* the Secret referenced by `Spec.Auth.SecretPath` (same Secret name, new `password` data — the normal way to rotate a credential without editing the CR) never causes the operator to replace the running Redis pods.

Root cause, confirmed in this fork's code:
- The StatefulSet's `ControllerRevisionHash` (what `UpdateRedisesPods` uses to decide which pods are stale and need replacing) is computed purely from the pod template's *structure*. The template's `REDIS_PASSWORD` env var is a `SecretKeyRef` pointing at the same Secret **name** — that reference never changes just because the Secret's data does, so the revision hash never changes and no pod is ever marked stale.
- Meanwhile, every check/heal call always fetches the *current* password via `k8s.GetRedisPassword` before talking to Redis. Once the Secret's value changes, the operator immediately starts getting `WRONGPASS` from every still-running pod (they're still using the old password loaded in their environment) — confirmed there's no fallback: `getRedisError`'s `WRONGPASS` branch in `service/redis/client.go` is metrics-labeling only.
- Net effect: nothing ever decides the pods need replacing, and the operator can't manage the cluster at all until someone manually deletes pods.

### Fix approach

This uses the exact same mechanism the operator already relies on for every other kind of pod rollout (image bumps, config changes): a change to the pod template triggers a new `ControllerRevisionHash`, which `UpdateRedisesPods` already rolls out one pod at a time, waiting for slaves to resync before touching the master (`checker.go`'s existing `UpdateRedisesPods`/`CheckRedisSlavesReady` logic — untouched by this PR). Stamping a checksum of the password onto the pod template is the standard, widely-used Kubernetes pattern for exactly this (the same trick Helm's `checksum/secret` annotation convention uses) — no new reconciliation logic, no new failure modes, reuses code that's already tested.

**Rollout note:** since this annotation doesn't exist on any currently-running pod, upgrading the operator to include this fix will cause **exactly one** rolling restart of Redis pods across every managed `RedisFailover`, even ones whose password hasn't changed (the annotation is simply new). This is expected, one-time, and by design — flagging it explicitly since it's an operationally visible change on upgrade, not a bug.

### Testing
- `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./operator/...` all pass clean.
- New test proves the actual bug-fix behavior (checksum changes with password); existing annotation/env tests updated to account for the new always-present key.

https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_