### PR TITLE
Detect partitioned sentinels via SENTINEL CKQUORUM readiness check

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -630,10 +630,19 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 			TimeoutSeconds:      5,
 			ProbeHandler: corev1.ProbeHandler{
 				Exec: &corev1.ExecAction{
+					// The first check (unchanged) gates readiness until this
+					// sentinel has been configured with a real master. The
+					// second check (SENTINEL CKQUORUM) additionally fails
+					// readiness if this sentinel can't currently reach enough
+					// peer sentinels to authorize a failover - e.g. during a
+					// network partition, where the original check alone would
+					// keep reporting Ready from a stale cached master address
+					// even though this sentinel is effectively isolated (see
+					// https://github.com/spotahome/redis-operator/issues/663).
 					Command: []string{
 						"sh",
 						"-c",
-						"redis-cli -h $(hostname) -p 26379 sentinel get-master-addr-by-name mymaster | head -n 1 | grep -vq '127.0.0.1'",
+						"redis-cli -h $(hostname) -p 26379 sentinel get-master-addr-by-name mymaster | head -n 1 | grep -vq '127.0.0.1' && redis-cli -h $(hostname) -p 26379 sentinel ckquorum mymaster | grep -q '^OK'",
 					},
 				},
 			},

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -2639,7 +2639,7 @@ func TestSentinelCustomReadinessProbe(t *testing.T) {
 						Command: []string{
 							"sh",
 							"-c",
-							"redis-cli -h $(hostname) -p 26379 sentinel get-master-addr-by-name mymaster | head -n 1 | grep -vq '127.0.0.1'",
+							"redis-cli -h $(hostname) -p 26379 sentinel get-master-addr-by-name mymaster | head -n 1 | grep -vq '127.0.0.1' && redis-cli -h $(hostname) -p 26379 sentinel ckquorum mymaster | grep -q '^OK'",
 						},
 					},
 				},


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- The default Sentinel Deployment readiness probe (`generateSentinelDeployment` in `generator.go`) now additionally requires `SENTINEL CKQUORUM mymaster` to report `OK`, ANDed onto the existing `get-master-addr-by-name` check.
- Updated the one existing test asserting the exact default probe command string.

### Why

Upstream issue [spotahome/redis-operator#663](https://github.com/spotahome/redis-operator/issues/663): the default readiness probe only checks whether a sentinel has *some* cached, non-loopback master address:

```
redis-cli -h $(hostname) -p 26379 sentinel get-master-addr-by-name mymaster | head -n 1 | grep -vq '127.0.0.1'
```

A sentinel isolated by a network partition still answers this from its last-known state — Kubernetes never marks it `NotReady`, so it stays in the sentinel Service's endpoint list. A client round-robining through that Service can land on the partitioned sentinel and get stale master info during exactly the moment (a partition/failover) when correctness matters most.

### Fix approach

The probe now ANDs on `redis-cli ... sentinel ckquorum mymaster | grep -q '^OK'`. `SENTINEL CKQUORUM` fails when the local sentinel can't currently reach enough peer sentinels to authorize a failover for the monitored master — exactly the partitioned/isolated case. The original check is left completely in place (still gates readiness until the sentinel has been configured with a real, non-loopback master), so this can only ever turn an *already-passing* sentinel `NotReady` in the new failure case; it can't change behavior for anything that was already failing readiness.

**Important correction I want to flag for reviewers:** I initially assumed `redis-cli`'s exit code would reflect a `NOQUORUM` reply and almost shipped a check based on that. I verified this against real `redis-server`/`redis-sentinel` binaries before writing the fix and found `redis-cli sentinel ckquorum <name>` **always exits 0**, regardless of whether the reply is `OK ...` or `NOQUORUM ...` — the failure only shows up in the reply text. That's why the probe greps the output for a leading `OK` rather than trusting the exit code. I validated both the positive path (quorum satisfiable → probe passes) and negative path (sentinel isolated from peers, quorum unreachable → probe fails) end-to-end against live redis-server/sentinel processes, not just by reasoning about it.

### Operational note

This changes default sentinel readiness *behavior* (not just a static rendered value) for every RedisFailover using the default probe (i.e., not overriding `Spec.Sentinel.CustomReadinessProbe`). On a healthy cluster this is a no-op — quorum is always satisfiable — but during a genuine partition or transient quorum contention, sentinels can now flip `NotReady` where they previously wouldn't have. That's the intended fix, but given the scale this fork runs at, I'd suggest validating in a lower environment before a fleet-wide rollout.

### Testing
- Verified the exact fix (both the redis-cli exit-code correction and the final combined probe) against real `redis-server`/`redis-sentinel` binaries in an isolated sandbox — not simulated.
- `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run ./operator/...` all pass clean.

https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_