### PR TITLE
Gitignore local .claude/ tooling directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .idea/
 /tmp
 vendor
+.claude/


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Add `.claude/` to `.gitignore`.

Claude Code's own agent-worktree scratch state (`.claude/worktrees/...`, created when a background subagent runs in an isolated worktree) was showing up as untracked files in the working copy. It's harness-internal tooling state, not project content, so it shouldn't be tracked or flagged as pending changes.

Trivial, non-functional change; no build/test impact.

https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_