### PR TITLE
Add test coverage for operator/redisfailover/util package

### DIFF
--- a/operator/redisfailover/util/label_test.go
+++ b/operator/redisfailover/util/label_test.go
@@ -1,0 +1,134 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/saremox/redis-operator/operator/redisfailover/util"
+)
+
+func TestMergeLabelsNoArguments(t *testing.T) {
+	res := util.MergeLabels()
+
+	assert.NotNil(t, res)
+	assert.Empty(t, res)
+}
+
+func TestMergeLabelsSingleMapIsCopy(t *testing.T) {
+	input := map[string]string{"a": "1", "b": "2"}
+
+	res := util.MergeLabels(input)
+
+	assert.Equal(t, input, res)
+
+	// Prove the result is a distinct map: mutating it must not mutate the input.
+	res["a"] = "mutated"
+	res["c"] = "3"
+
+	assert.Equal(t, "1", input["a"], "mutating the merged result must not affect the source map")
+	_, ok := input["c"]
+	assert.False(t, ok, "mutating the merged result must not affect the source map")
+}
+
+func TestMergeLabelsUnionNoOverlap(t *testing.T) {
+	a := map[string]string{"a": "1"}
+	b := map[string]string{"b": "2"}
+	c := map[string]string{"c": "3"}
+
+	res := util.MergeLabels(a, b, c)
+
+	assert.Equal(t, map[string]string{"a": "1", "b": "2", "c": "3"}, res)
+}
+
+func TestMergeLabelsLaterArgumentWins(t *testing.T) {
+	first := map[string]string{"a": "1"}
+	second := map[string]string{"a": "2"}
+
+	res := util.MergeLabels(first, second)
+
+	assert.Equal(t, map[string]string{"a": "2"}, res)
+}
+
+func TestMergeLabelsLaterArgumentWinsAmongMany(t *testing.T) {
+	res := util.MergeLabels(
+		map[string]string{"a": "1", "shared": "first"},
+		map[string]string{"b": "2", "shared": "second"},
+		map[string]string{"c": "3", "shared": "third"},
+	)
+
+	assert.Equal(t, map[string]string{
+		"a":      "1",
+		"b":      "2",
+		"c":      "3",
+		"shared": "third",
+	}, res)
+}
+
+func TestMergeLabelsNilMapsAreSkipped(t *testing.T) {
+	res := util.MergeLabels(nil, map[string]string{"a": "1"}, nil)
+
+	assert.Equal(t, map[string]string{"a": "1"}, res)
+}
+
+func TestMergeLabelsAllNilMaps(t *testing.T) {
+	res := util.MergeLabels(nil, nil)
+
+	assert.NotNil(t, res)
+	assert.Empty(t, res)
+}
+
+func TestMergeAnnotationsNoArguments(t *testing.T) {
+	res := util.MergeAnnotations()
+
+	assert.NotNil(t, res)
+	assert.Empty(t, res)
+}
+
+func TestMergeAnnotationsSingleMapIsCopy(t *testing.T) {
+	input := map[string]string{"a": "1", "b": "2"}
+
+	res := util.MergeAnnotations(input)
+
+	assert.Equal(t, input, res)
+
+	// Prove the result is a distinct map: mutating it must not mutate the input.
+	res["a"] = "mutated"
+	res["c"] = "3"
+
+	assert.Equal(t, "1", input["a"], "mutating the merged result must not affect the source map")
+	_, ok := input["c"]
+	assert.False(t, ok, "mutating the merged result must not affect the source map")
+}
+
+func TestMergeAnnotationsUnionNoOverlap(t *testing.T) {
+	a := map[string]string{"a": "1"}
+	b := map[string]string{"b": "2"}
+	c := map[string]string{"c": "3"}
+
+	res := util.MergeAnnotations(a, b, c)
+
+	assert.Equal(t, map[string]string{"a": "1", "b": "2", "c": "3"}, res)
+}
+
+func TestMergeAnnotationsLaterArgumentWins(t *testing.T) {
+	first := map[string]string{"a": "1"}
+	second := map[string]string{"a": "2"}
+
+	res := util.MergeAnnotations(first, second)
+
+	assert.Equal(t, map[string]string{"a": "2"}, res)
+}
+
+func TestMergeAnnotationsNilMapsAreSkipped(t *testing.T) {
+	res := util.MergeAnnotations(nil, map[string]string{"a": "1"}, nil)
+
+	assert.Equal(t, map[string]string{"a": "1"}, res)
+}
+
+func TestMergeAnnotationsAllNilMaps(t *testing.T) {
+	res := util.MergeAnnotations(nil, nil)
+
+	assert.NotNil(t, res)
+	assert.Empty(t, res)
+}

--- a/operator/redisfailover/util/pod_test.go
+++ b/operator/redisfailover/util/pod_test.go
@@ -1,0 +1,222 @@
+package util_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/saremox/redis-operator/operator/redisfailover/util"
+)
+
+func TestPodIsScheduling(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "pod stuck in ContainerCreating/ImagePullBackOff reports Phase Pending with no DeletionTimestamp - this is the exact condition that must block premature master-pod deletion during a stuck rollout",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pending phase with no deletion timestamp is scheduling",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "deletion timestamp set with Running phase is scheduling regardless of phase",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "deletion timestamp set with Failed phase is still scheduling",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "deletion timestamp set with Succeeded phase is still scheduling",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodSucceeded,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "deletion timestamp set with Pending phase is scheduling",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "running phase with no deletion timestamp is not scheduling",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "failed phase with no deletion timestamp is not scheduling",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "succeeded phase with no deletion timestamp is not scheduling",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodSucceeded,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "unknown phase with no deletion timestamp is not scheduling",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodUnknown,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, util.PodIsScheduling(test.pod))
+		})
+	}
+}
+
+func TestPodIsTerminal(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name: "failed phase is terminal",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodFailed,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "succeeded phase is terminal",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodSucceeded,
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "pending phase is not terminal",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "running phase is not terminal",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "unknown phase is not terminal",
+			pod: &corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodUnknown,
+				},
+			},
+			expected: false,
+		},
+		{
+			// This distinction matters for AreAllRunning: a DeletionTimestamp alone makes a
+			// pod "scheduling" (PodIsScheduling), which short-circuits the whole check to
+			// false, but it must NOT make the pod "terminal" (PodIsTerminal) - only an actual
+			// Failed/Succeeded phase does that. Terminal pods are skipped/not counted by
+			// AreAllRunning, whereas a scheduling pod fails the check outright.
+			name: "deletion timestamp alone with Running phase does not make the pod terminal",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "deletion timestamp alone with Pending phase does not make the pod terminal",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &now,
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, util.PodIsTerminal(test.pod))
+		})
+	}
+}


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Add `operator/redisfailover/util/pod_test.go`: table-driven tests for `PodIsScheduling` and `PodIsTerminal`.
- Add `operator/redisfailover/util/label_test.go`: table-driven tests for `MergeLabels` and `MergeAnnotations`.
- Test-only change — no production code (`pod.go`, `label.go`, or anything else) is modified.

## Why this package matters

`operator/redisfailover/util/` previously had zero direct test coverage, despite being load-bearing:

- `PodIsScheduling`/`PodIsTerminal` back `AreAllRunning` in `operator/redisfailover/service/check.go`, which gates `IsRedisRunning`. This is the exact mechanism that ensures the operator refuses to proceed with pod-deletion/failover logic while any pod is `Pending` (e.g. stuck in `ContainerCreating`/`ImagePullBackOff`) or has a `DeletionTimestamp` set — i.e. it prevents a data-loss scenario where a master pod could be deleted mid-rollout. That safety property was previously only exercised indirectly through `AreAllRunning`'s own tests, which don't isolate these two functions' exact boundary conditions. This PR adds a test explicitly named/commented around the stuck-`ContainerCreating`/`ImagePullBackOff` → `Phase == Pending` case, plus a case proving a `DeletionTimestamp` alone (with e.g. `Phase == Running`) does *not* make a pod terminal — only `Failed`/`Succeeded` do, which matters because `AreAllRunning` treats "scheduling" pods (short-circuit to false) differently from "terminal" pods (skipped/not counted).
- `MergeLabels`/`MergeAnnotations` are used throughout `operator/redisfailover/service/generator.go` for labels/annotations on every generated Service, Deployment, StatefulSet, and ConfigMap. This PR pins down their documented "later-argument-wins-on-key-collision" merge semantics explicitly, plus copy semantics (mutating the result doesn't mutate inputs) and nil-map handling (skipped without panic).

## Coverage

`go test ./operator/redisfailover/util/... -cover` → **100.0% of statements**.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all passing
- `golangci-lint run ./operator/...` — 0 issues
- `go test ./operator/redisfailover/util/... -cover` — 100.0% coverage

No bugs were found in `pod.go`/`label.go` during this review; behavior matched documented semantics in all tested cases.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_