### PR TITLE
Add test coverage for GetStatefulSetPods, UpdatePodLabels, GetRedisPassword

### DIFF
--- a/service/k8s/pod_test.go
+++ b/service/k8s/pod_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -32,6 +33,135 @@ func newPodGetAction(ns, name string) kubetesting.GetActionImpl {
 
 func newPodCreateAction(ns string, pod *corev1.Pod) kubetesting.CreateActionImpl {
 	return kubetesting.NewCreateAction(podsGroup, ns, pod)
+}
+
+// TestPodServiceUpdatePodLabels exercises UpdatePodLabels, the mechanism
+// behind master/slave role-label updates during failover. It builds a JSON
+// Patch with Op "replace", which per RFC 6902 requires the target path to
+// already exist -- these tests prove that behavior against a real fake
+// clientset rather than assuming it.
+func TestPodServiceUpdatePodLabels(t *testing.T) {
+	testns := "testns"
+
+	t.Run("updates an existing label to a new value", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testpod",
+				Namespace: testns,
+				Labels: map[string]string{
+					"role": "slave",
+				},
+			},
+		}
+		mcli := kubernetes.NewSimpleClientset(pod)
+		service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.UpdatePodLabels(testns, "testpod", map[string]string{"role": "master"})
+		assertTest.NoError(err)
+
+		got, err := mcli.CoreV1().Pods(testns).Get(context.TODO(), "testpod", metav1.GetOptions{})
+		assertTest.NoError(err)
+		assertTest.Equal("master", got.Labels["role"])
+	})
+
+	t.Run("updates multiple existing labels at once", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testpod",
+				Namespace: testns,
+				Labels: map[string]string{
+					"role":  "slave",
+					"ready": "false",
+				},
+			},
+		}
+		mcli := kubernetes.NewSimpleClientset(pod)
+		service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.UpdatePodLabels(testns, "testpod", map[string]string{
+			"role":  "master",
+			"ready": "true",
+		})
+		assertTest.NoError(err)
+
+		got, err := mcli.CoreV1().Pods(testns).Get(context.TODO(), "testpod", metav1.GetOptions{})
+		assertTest.NoError(err)
+		assertTest.Equal("master", got.Labels["role"])
+		assertTest.Equal("true", got.Labels["ready"])
+	})
+
+	t.Run("returns an error when the pod does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewSimpleClientset()
+		service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.UpdatePodLabels(testns, "does-not-exist", map[string]string{"role": "master"})
+		assertTest.Error(err)
+	})
+
+	t.Run("documents actual replace semantics: a label key absent from the pod but with an existing labels map is upserted, not rejected", func(t *testing.T) {
+		// NOTE: strict RFC 6902 says "replace" must fail when the target path
+		// does not already exist. In practice, the JSON Patch library used
+		// here (gopkg.in/evanphx/json-patch.v4, via client-go's fake and real
+		// Patch codepaths) does NOT enforce that for object/map members: its
+		// "replace" implementation only errors when some *ancestor* path
+		// segment is entirely missing (see the next sub-test, where the pod
+		// has no labels map at all). When the labels map already exists --
+		// true for every pod in this codebase, since a default role label is
+		// baked into the pod template at creation -- "replace" against a
+		// label key that isn't present yet silently succeeds and adds it,
+		// behaving like an upsert rather than a strict replace. This is a
+		// real deviation from RFC 6902 in the dependency, not a bug in
+		// UpdatePodLabels itself -- documented here rather than fixed.
+		assertTest := assert.New(t)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testpod",
+				Namespace: testns,
+				Labels: map[string]string{
+					"role": "slave",
+				},
+			},
+		}
+		mcli := kubernetes.NewSimpleClientset(pod)
+		service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.UpdatePodLabels(testns, "testpod", map[string]string{"new-label-key": "value"})
+		assertTest.NoError(err)
+
+		got, getErr := mcli.CoreV1().Pods(testns).Get(context.TODO(), "testpod", metav1.GetOptions{})
+		assertTest.NoError(getErr)
+		assertTest.Equal("slave", got.Labels["role"], "pre-existing labels are left untouched")
+		assertTest.Equal("value", got.Labels["new-label-key"], "the new key is upserted rather than rejected")
+	})
+
+	t.Run("replace fails when the pod has no labels map at all", func(t *testing.T) {
+		// This is the actual failure mode of "replace": it errors only when
+		// an ancestor container of the target path (here, /metadata/labels
+		// itself) does not exist on the object, not merely when the leaf key
+		// is missing. Every pod in this codebase gets a default role label at
+		// creation, so its labels map always exists in practice -- this case
+		// documents what would happen if that ever weren't true.
+		assertTest := assert.New(t)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nolabelspod",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewSimpleClientset(pod)
+		service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.UpdatePodLabels(testns, "nolabelspod", map[string]string{"role": "master"})
+		assertTest.Error(err, "replace against a path whose parent container is entirely absent must fail")
+	})
 }
 
 func TestPodServiceGetCreateOrUpdate(t *testing.T) {

--- a/service/k8s/statefulset_test.go
+++ b/service/k8s/statefulset_test.go
@@ -38,6 +38,150 @@ func newStatefulSetCreateAction(ns string, statefulSet *appsv1.StatefulSet) kube
 	return kubetesting.NewCreateAction(statefulSetsGroup, ns, statefulSet)
 }
 
+// TestStatefulSetServiceGetStatefulSetPods exercises the real selector-building
+// logic in GetStatefulSetPods: it must list only the pods that belong to the
+// named StatefulSet, scoped by both the StatefulSet's own MatchLabels selector
+// and namespace. This is the exact property a recent fix relies on to prevent
+// replicas from attaching to the wrong RedisFailover's master after pod-IP
+// reuse across namespaces, so it uses a real fake clientset (not hand-rolled
+// reactors) to get genuine label-selector and namespace filtering semantics.
+func TestStatefulSetServiceGetStatefulSetPods(t *testing.T) {
+	testns := "testns"
+	otherns := "otherns"
+	stsName := "teststatefulset"
+
+	testStatefulSet := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stsName,
+			Namespace: testns,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app":       "redis",
+					"component": "master",
+				},
+			},
+		},
+	}
+
+	matchingPod1 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "matching-pod-1",
+			Namespace: testns,
+			Labels: map[string]string{
+				"app":       "redis",
+				"component": "master",
+			},
+		},
+	}
+	matchingPod2 := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "matching-pod-2",
+			Namespace: testns,
+			Labels: map[string]string{
+				"app":       "redis",
+				"component": "master",
+				"extra":     "label-should-not-matter",
+			},
+		},
+	}
+	// Same namespace, but does not carry all of the StatefulSet's selector labels.
+	nonMatchingLabelsPod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "non-matching-labels-pod",
+			Namespace: testns,
+			Labels: map[string]string{
+				"app":       "redis",
+				"component": "slave",
+			},
+		},
+	}
+	// Different namespace, but carries the exact same labels as the matching pods.
+	// This proves the selector is correctly namespace-scoped: same labels alone
+	// must not be enough to match across namespaces (the #698-class fix property).
+	crossNamespacePod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cross-namespace-pod",
+			Namespace: otherns,
+			Labels: map[string]string{
+				"app":       "redis",
+				"component": "master",
+			},
+		},
+	}
+
+	mcli := kubernetes.NewSimpleClientset(
+		testStatefulSet,
+		matchingPod1,
+		matchingPod2,
+		nonMatchingLabelsPod,
+		crossNamespacePod,
+	)
+
+	service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
+
+	t.Run("returns exactly the pods matching selector and namespace", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		podList, err := service.GetStatefulSetPods(testns, stsName)
+		assertTest.NoError(err)
+		assertTest.NotNil(podList)
+
+		gotNames := map[string]bool{}
+		for _, p := range podList.Items {
+			gotNames[p.Name] = true
+		}
+
+		assertTest.Len(podList.Items, 2)
+		assertTest.True(gotNames["matching-pod-1"])
+		assertTest.True(gotNames["matching-pod-2"])
+		assertTest.False(gotNames["non-matching-labels-pod"], "pod with a different label value must be excluded")
+		assertTest.False(gotNames["cross-namespace-pod"], "pod in a different namespace with identical labels must be excluded")
+	})
+
+	t.Run("propagates the error when the StatefulSet itself does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		podList, err := service.GetStatefulSetPods(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.Nil(podList)
+	})
+
+	t.Run("an empty MatchLabels selector matches every pod in the namespace", func(t *testing.T) {
+		// This documents the actual behavior of GetStatefulSetPods when
+		// Spec.Selector.MatchLabels is empty: the joined selector string is
+		// empty, which k8s treats as "select everything" (no restriction),
+		// so every pod in the namespace is returned -- not zero pods.
+		assertTest := assert.New(t)
+
+		emptySelectorSts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "empty-selector-sts",
+				Namespace: testns,
+			},
+			Spec: appsv1.StatefulSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{},
+				},
+			},
+		}
+
+		mcli2 := kubernetes.NewSimpleClientset(
+			emptySelectorSts,
+			matchingPod1,
+			matchingPod2,
+			nonMatchingLabelsPod,
+		)
+		service2 := k8s.NewStatefulSetService(mcli2, log.Dummy, metrics.Dummy)
+
+		podList, err := service2.GetStatefulSetPods(testns, "empty-selector-sts")
+		assertTest.NoError(err)
+		assertTest.NotNil(podList)
+		assertTest.Len(podList.Items, 3, "an empty selector matches every pod in the namespace")
+	})
+}
+
 func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
 	testStatefulSet := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{

--- a/service/k8s/util_test.go
+++ b/service/k8s/util_test.go
@@ -1,0 +1,123 @@
+package k8s
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubernetes "k8s.io/client-go/kubernetes/fake"
+
+	redisfailoverv1 "github.com/saremox/redis-operator/api/redisfailover/v1"
+	"github.com/saremox/redis-operator/log"
+	"github.com/saremox/redis-operator/metrics"
+)
+
+// newTestServices builds a real k8s.Services implementation backed by a fake
+// clientset, with only the Secret sub-service populated -- GetRedisPassword
+// only ever calls s.GetSecret, and this is an internal (package k8s) test so
+// it can use the unexported `services` struct directly instead of the mocks
+// this package deliberately avoids.
+func newTestServices(kubeClient *kubernetes.Clientset) Services {
+	return &services{
+		Secret: NewSecretService(kubeClient, log.Dummy, metrics.Dummy),
+	}
+}
+
+func TestGetRedisPassword(t *testing.T) {
+	testns := "testns"
+
+	t.Run("no SecretPath configured returns a blank password with no error", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		// No secret seeded at all: if GetRedisPassword attempted to read a
+		// secret here, the fake Get would fail (not found) and this
+		// assertion on a nil error would catch it.
+		mcli := kubernetes.NewSimpleClientset()
+		s := newTestServices(mcli)
+
+		rf := &redisfailoverv1.RedisFailover{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testns},
+		}
+
+		password, err := GetRedisPassword(s, rf)
+		assertTest.NoError(err)
+		assertTest.Equal("", password)
+	})
+
+	t.Run("SecretPath set and secret has a password field returns the password", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "redis-auth",
+				Namespace: testns,
+			},
+			Data: map[string][]byte{
+				"password": []byte("s3cr3t"),
+			},
+		}
+		mcli := kubernetes.NewSimpleClientset(secret)
+		s := newTestServices(mcli)
+
+		rf := &redisfailoverv1.RedisFailover{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testns},
+			Spec: redisfailoverv1.RedisFailoverSpec{
+				Auth: redisfailoverv1.AuthSettings{SecretPath: "redis-auth"},
+			},
+		}
+
+		password, err := GetRedisPassword(s, rf)
+		assertTest.NoError(err)
+		assertTest.Equal("s3cr3t", password)
+	})
+
+	t.Run("SecretPath set but the secret does not exist propagates the error", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewSimpleClientset()
+		s := newTestServices(mcli)
+
+		rf := &redisfailoverv1.RedisFailover{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testns},
+			Spec: redisfailoverv1.RedisFailoverSpec{
+				Auth: redisfailoverv1.AuthSettings{SecretPath: "does-not-exist"},
+			},
+		}
+
+		password, err := GetRedisPassword(s, rf)
+		assertTest.Error(err)
+		assertTest.Equal("", password)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+
+	t.Run("SecretPath set and secret exists but has no password field returns a descriptive error", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "redis-auth",
+				Namespace: testns,
+			},
+			Data: map[string][]byte{
+				"other-field": []byte("irrelevant"),
+			},
+		}
+		mcli := kubernetes.NewSimpleClientset(secret)
+		s := newTestServices(mcli)
+
+		rf := &redisfailoverv1.RedisFailover{
+			ObjectMeta: metav1.ObjectMeta{Namespace: testns},
+			Spec: redisfailoverv1.RedisFailoverSpec{
+				Auth: redisfailoverv1.AuthSettings{SecretPath: "redis-auth"},
+			},
+		}
+
+		password, err := GetRedisPassword(s, rf)
+		assertTest.Error(err)
+		assertTest.Equal("", password)
+		assertTest.Equal(`secret "redis-auth" does not have a password field`, err.Error())
+	})
+}
+


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Add direct unit test coverage for three `service/k8s` functions, part of a coordinated code-review coverage pass over that package
- No production code changed (`statefulset.go`, `pod.go`, `util.go` are untouched) — test-only

## Why these three, and not the rest of the 0%-coverage `service/k8s` wrappers

A coverage pass found most `Get`/`List`/`Delete` wrapper functions in `service/k8s` at 0%, but the bulk of them are pure one-line client-go pass-throughs (e.g. `client.Get(...)`) and were flagged as low-value/low-priority. These three functions were called out specifically because they contain real logic beyond a pass-through, and production code depends on that logic behaving correctly:

- **`statefulset.go:62 GetStatefulSetPods`** — builds a label selector from the StatefulSet's own `Spec.Selector.MatchLabels` and lists pods by it. A recent fix preventing replicas from attaching to the wrong RedisFailover's master after pod-IP reuse across namespaces depends entirely on this returning exactly the pods belonging to the named StatefulSet, scoped correctly by namespace *and* selector. It previously had no direct test — only indirect coverage via callers that mock this method away, which never exercises the real selector-building logic.
- **`pod.go:110 UpdatePodLabels`** — builds a JSON Patch (`Op: "replace"`) used to drive master/slave role-label updates during failover.
- **`util.go:13 GetRedisPassword`** — called on nearly every Redis operation across the codebase to fetch the current auth password, and is the function a recent feature (rolling Redis pods when the auth Secret's password value changes) is built entirely around.

## What each test proves

**`TestStatefulSetServiceGetStatefulSetPods`** (`service/k8s/statefulset_test.go`) — uses a real `fake.NewSimpleClientset` (not hand-rolled reactors) to get genuine label-selector + namespace filtering semantics:
- Returns exactly the pods matching both the StatefulSet's selector labels *and* namespace — pods in the same namespace with different labels are excluded, and pods in a *different* namespace with identical labels are excluded (the specific namespace-scoping property the cross-namespace-master fix relies on).
- `GetStatefulSet` erroring (StatefulSet not found) propagates the error with no pod list.
- Documents the actual behavior of an empty `MatchLabels` selector: it matches every pod in the namespace (not zero pods), since the joined selector string is empty.

**`TestPodServiceUpdatePodLabels`** (`service/k8s/pod_test.go`):
- A pod with an existing label key gets that key's value updated, verified by re-fetching the stored object from the fake clientset.
- Multiple labels can be updated in a single call.
- Patching a pod name that doesn't exist returns an error.
- Two cases documenting the real behavior of the underlying JSON Patch library (`gopkg.in/evanphx/json-patch.v4`) for `Op: "replace"` against a label key that isn't already present — see **Finding** below, since this deviates from what a strict RFC 6902 reading would suggest.

**`TestGetRedisPassword`** (new `service/k8s/util_test.go`, internal `package k8s` test so it can build a real `k8s.Services` via the unexported `services` struct with only `Secret` populated, backed by a fake clientset — mirrors this package's existing no-testify-mocks convention):
- `Spec.Auth.SecretPath == ""` → `("", nil)`, with no Secret seeded at all (proving `GetSecret` isn't even attempted).
- `SecretPath` set, Secret exists with a `password` key → returns that value.
- `SecretPath` set, Secret doesn't exist → the `GetSecret` error propagates (`errors.IsNotFound`).
- `SecretPath` set, Secret exists but has no `password` key → the specific `secret "<path>" does not have a password field` error.

## Coverage (service/k8s package)

| Function | Before | After |
|---|---|---|
| `GetStatefulSetPods` | 0.0% | 100.0% |
| `UpdatePodLabels` | 0.0% | 100.0% |
| `GetRedisPassword` | 0.0% | 100.0% |
| package total | 61.7% | 68.9% |

## Finding (not fixed, documented only — this PR is test-only)

While writing the `UpdatePodLabels` tests I found that its JSON Patch `Op: "replace"` does **not** actually require the target label key to pre-exist, contrary to a strict RFC 6902 reading. The library used here (`gopkg.in/evanphx/json-patch.v4`, via client-go's Patch codepath) only errors when an *ancestor* path segment is entirely missing — for `/metadata/labels/<key>`, that means it only fails if the pod has **no labels map at all**. If the pod already has a labels map (true for every pod in this codebase, since a default role label is baked into the pod template at creation), `replace` against a brand-new key silently succeeds and adds it, behaving like an upsert rather than a strict replace. This is a real deviation from RFC 6902 in the dependency's behavior, not a bug in `UpdatePodLabels` itself, and doesn't affect current callers (which only ever replace pre-existing keys) — flagging it here per the task instructions rather than changing production code. Both cases (labels map present with a new key vs. no labels map at all) are captured as sub-tests with comments in `pod_test.go`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] `golangci-lint run ./service/...` (0 issues)
- [x] Coverage verified via `go test ./service/k8s/... -coverprofile=... && go tool cover -func=...`


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_