### PR TITLE
Add working code coverage reporting (Codecov)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,10 +44,11 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - run: make ci-unit-test
+      - run: make ci-unit-test-coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
         with:
+          files: ./coverage.out
           fail_ci_if_error: false
 
   integration-test:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tmp
 vendor
 .claude/
+coverage.out

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,14 @@ PORT := 9710
 
 # CMDs
 UNIT_TEST_CMD := go test `go list ./... | grep -v /vendor/` -v
+# Packages that actually contain test files (in-package or external "_test"
+# packages), respecting build tags (e.g. excludes test/integration, which is
+# gated behind the "integration" build tag). Coverage is scoped to these so
+# generated/no-test packages (client/k8s clientset, mocks, cmd/*, ...) aren't
+# fed through the coverage instrumentation, which otherwise trips
+# `go: no such tool "covdata"` on toolchains that don't ship it.
+UNIT_TEST_COVERAGE_PKGS_CMD := go list -f '{{if or .TestGoFiles .XTestGoFiles}}{{.ImportPath}}{{end}}' ./... | grep -v /vendor/
+UNIT_TEST_COVERAGE_CMD := go test `$(UNIT_TEST_COVERAGE_PKGS_CMD)` -v -coverprofile=coverage.out -covermode=atomic
 GO_GENERATE_CMD := go generate `go list ./... | grep -v /vendor/`
 GO_INTEGRATION_TEST_CMD := go test `go list ./... | grep test/integration` -v -tags='integration'
 GET_DEPS_CMD := dep ensure
@@ -143,6 +151,12 @@ unit-test: docker-build
 .PHONY: ci-unit-test
 ci-unit-test:
 	$(UNIT_TEST_CMD)
+
+# Same unit tests as ci-unit-test, but also produces coverage.out for
+# uploading to Codecov. Used by the CI unit-test job.
+.PHONY: ci-unit-test-coverage
+ci-unit-test-coverage:
+	$(UNIT_TEST_COVERAGE_CMD)
 
 .PHONY: ci-integration-test
 ci-integration-test:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a fork of the `spotahome/redis-operator` repository.
 
 [![Build Status](https://github.com/Saremox/redis-operator/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/Saremox/redis-operator)
 [![Go Report Card](https://goreportcard.com/badge/github.com/Saremox/redis-operator)](https://goreportcard.com/report/github.com/Saremox/redis-operator)
+[![codecov](https://codecov.io/gh/Saremox/redis-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/Saremox/redis-operator)
 
 Redis Operator creates/configures/manages redis-failovers atop Kubernetes.
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+
+ignore:
+  - "mocks/**"
+  - "client/k8s/clientset/**"
+  - "**/zz_generated.deepcopy.go"
+  - "test/**"


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Make the "Upload coverage to Codecov" step in the `unit-test` CI job actually upload real coverage data (previously a silent no-op).
- Add a `codecov.yml` with non-blocking, informational status checks and a sensible ignore list for generated/scaffolding code.
- Add a Codecov badge to the README alongside the existing Build Status and Go Report Card badges.

## Why this was needed

`.github/workflows/ci.yaml`'s `unit-test` job already had a `codecov/codecov-action@v7` upload step, but the Makefile's `UNIT_TEST_CMD` (used by `ci-unit-test`, which the job ran) never passed `-coverprofile`:

```make
UNIT_TEST_CMD := go test `go list ./... | grep -v /vendor/` -v
```

No coverage file was ever generated, so the upload step had nothing to upload. `fail_ci_if_error: false` on the step meant this failure was silently swallowed — it's been a no-op since it was added.

## What changed

- **Makefile**: added `UNIT_TEST_COVERAGE_CMD` and a new `ci-unit-test-coverage` target that runs the unit tests with `-coverprofile=coverage.out -covermode=atomic`. The existing `ci-unit-test` and `test` targets are untouched, so nothing that already calls them is affected.

  The coverage command is deliberately scoped to only the packages that actually contain test files (via `go list -f '{{if or .TestGoFiles .XTestGoFiles}}...'`), rather than the whole module. I verified locally that running `go test ./... -coverprofile=... -covermode=atomic` across the *whole* module (including packages with zero test files, e.g. the generated `client/k8s/clientset/...` and `mocks/...`) is a **real, non-cosmetic failure** in this environment: it prints `go: no such tool "covdata"` for every no-test-file package and the overall command exits **1** (I confirmed via explicit exit-code checks, not just eyeballing output) — even though a real `coverage.out` with valid content is still produced for the packages that do have tests. Scoping the package list to only tested packages sidesteps this cleanly regardless of whether a given toolchain ships `covdata`, and also avoids depending on `-covermode` to work around it (I also confirmed the failure was unrelated to atomic vs. count coverage mode — same error either way).

- **`.github/workflows/ci.yaml`**: the `unit-test` job now runs `make ci-unit-test-coverage` and the codecov-action step passes `files: ./coverage.out` explicitly instead of relying on auto-detection. `fail_ci_if_error: false` is kept — coverage reporting failing should not block the build.

- **`codecov.yml`** (new): `informational: true` for both project and patch coverage status checks (visibility only, not gating merges), plus an `ignore` list for generated/scaffolding code:
  - `mocks/**` — generated mocks
  - `client/k8s/clientset/**` — generated Kubernetes clientset
  - `**/zz_generated.deepcopy.go` — generated deepcopy code (confirmed present at `api/redisfailover/v1/zz_generated.deepcopy.go`)
  - `test/**` — integration test helpers

  I verified these paths actually exist in the repo before adding them. Without the ignore list, `zz_generated.deepcopy.go` in particular would show up in `coverage.out` (it's part of a package that *does* have unit tests, `api/redisfailover/v1`) with a permanent 0% and drag down the reported percentage in a way that isn't actionable.

- **README.md**: added `[[codecov](https://codecov.io/gh/Saremox/redis-operator/branch/main/graph/badge.svg)](https://codecov.io/gh/Saremox/redis-operator)` next to the existing two badges. This is the current documented Codecov badge format (verified via a web search against Codecov's docs) and requires no token for a public repo.

- **`.gitignore`**: added `coverage.out`.

## Verification performed

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `go test ./...` (unmodified, no coverage flags) — passes, exit 0, confirms normal test running is unaffected.
- `make ci-unit-test` (existing target, untouched) — still passes as before.
- `make ci-unit-test-coverage` (new target) — passes, exit 0, produces a real `coverage.out` (~1200 lines, not empty/header-only). Local total coverage computed via `go tool cover -func` was in the ~54–59% range across a couple of runs (small run-to-run variance in one package's numbers, not investigated further — out of scope for this change; the point verified is that the file is real and non-trivial).
- `golangci-lint run ./...` — `0 issues`.
- Pushed the branch and checked the GitHub Actions run for **this PR's own `unit-test` job**: [describe what you actually observed once the run has completed — I have not yet seen the run for this specific push at the time of writing this description; will report the precise outcome, including whether the Codecov upload step logged a successful upload URL/message, in a follow-up comment].

Also checked for a possible in-flight conflict on this same job (e.g. a `redis-server` install step) before opening this PR: no open PR touches `.github/workflows/ci.yaml` right now, and `main` had no such change in the commits merged since I branched, so this diff applies cleanly and doesn't revert or clash with anyone else's work on that file.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_