### PR TITLE
Add test harness and coverage for service/redis client

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,8 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+      - name: Install redis-server (for service/redis unit tests)
+        run: sudo apt-get update && sudo apt-get install -y redis-server
       - run: make ci-unit-test-coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7

--- a/service/redis/client_test.go
+++ b/service/redis/client_test.go
@@ -1,0 +1,630 @@
+package redis
+
+// Tests in this file exercise service/redis's Client against real
+// redis-server / redis-server --sentinel subprocesses (see testutil_test.go
+// for the harness). This package previously had zero test coverage even
+// though it is the entire wire-protocol layer the operator uses to talk to
+// Redis and Sentinel.
+//
+// Two behaviours here were verified empirically against real Redis 7.0.15
+// rather than assumed, per the investigation that prompted this test suite:
+//   - SENTINEL CKQUORUM's NOQUORUM outcome (see TestSentinelCheckQuorum_NoQuorum).
+//   - CONFIG SET aclfile's immutability (see TestSetCustomRedisConfig_ACLFile).
+// Both surfaced apparent bugs in client.go; see the comments on those tests.
+// Per the task instructions, these are reported, not fixed, here.
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	rediscli "github.com/go-redis/redis/v8"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/saremox/redis-operator/metrics"
+)
+
+func newTestClient() Client {
+	return New(metrics.Dummy)
+}
+
+// ---------------------------------------------------------------------
+// IsMaster / GetSlaveOf / SlaveIsReady / GetReplicationInfo
+// (shared read-only master+replica+sentinel environment)
+// ---------------------------------------------------------------------
+
+func TestIsMaster(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+
+	isMaster, err := c.IsMaster(env.master.IP, strconv.Itoa(env.master.Port), "")
+	require.NoError(t, err)
+	assert.True(t, isMaster, "a freshly started standalone redis-server should report role:master")
+
+	isMaster, err = c.IsMaster(env.replica.IP, strconv.Itoa(env.replica.Port), "")
+	require.NoError(t, err)
+	assert.False(t, isMaster, "a replica should not report role:master")
+}
+
+func TestGetSlaveOf(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+
+	masterOf, err := c.GetSlaveOf(env.master.IP, strconv.Itoa(env.master.Port), "")
+	require.NoError(t, err)
+	assert.Empty(t, masterOf, "a master has no master_host, so GetSlaveOf should return empty string")
+
+	masterOf, err = c.GetSlaveOf(env.replica.IP, strconv.Itoa(env.replica.Port), "")
+	require.NoError(t, err)
+	assert.Equal(t, env.master.IP, masterOf)
+}
+
+// TestSlaveIsReady_LoopbackMasterHostNeverReady documents a real quirk found
+// while building this test suite (not fixed here, per instructions - see the
+// task summary for the full report):
+//
+// SlaveIsReady's readiness check is:
+//
+//	ok := !strings.Contains(info, redisSyncing) &&
+//	    !strings.Contains(info, redisMasterSillPending) &&
+//	    strings.Contains(info, redisLinkUp)
+//
+// where redisMasterSillPending is the literal string "master_host:127.0.0.1".
+// That's presumably meant to catch a transitional state (a pod that hasn't
+// picked up its real master's address yet), but it's implemented as an exact
+// match on the loopback address rather than on some other placeholder value.
+// The practical effect: a replica whose master genuinely *is* reachable at
+// 127.0.0.1 is reported "not ready" by SlaveIsReady forever, even once
+// replication is fully caught up (master_link_status:up) - because the
+// string "master_host:127.0.0.1" is present in INFO replication regardless
+// of sync state. This is exactly the shared test master/replica pair in this
+// package (everything here binds to 127.0.0.1), so it's confirmed directly
+// below rather than asserted as a TODO.
+func TestSlaveIsReady_LoopbackMasterHostNeverReady(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+
+	// Give replication as long as we reasonably can to fully catch up, to
+	// make sure what we're observing is the master_host:127.0.0.1 quirk and
+	// not merely "still syncing".
+	waitForCondition(t, 10*time.Second, func() bool {
+		info, err := c.GetReplicationInfo(env.replica.IP, strconv.Itoa(env.replica.Port), "")
+		return err == nil && info.MasterLinkStatus == "up" && !info.SyncInProgress
+	})
+	info, err := c.GetReplicationInfo(env.replica.IP, strconv.Itoa(env.replica.Port), "")
+	require.NoError(t, err)
+	require.Equal(t, "up", info.MasterLinkStatus, "replication should be fully caught up before this assertion is meaningful")
+
+	ok, err := c.SlaveIsReady(env.replica.IP, strconv.Itoa(env.replica.Port), "")
+	require.NoError(t, err)
+	assert.False(t, ok, "SlaveIsReady incorrectly reports not-ready whenever master_host is literally 127.0.0.1, regardless of actual sync state - see comment above")
+
+	// A master has no master_link_status line at all, so SlaveIsReady should
+	// report false for it too (but for the entirely unrelated, correct
+	// reason that it just isn't a slave).
+	ok, err = c.SlaveIsReady(env.master.IP, strconv.Itoa(env.master.Port), "")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+// TestSlaveIsReady_NonLoopbackMaster is the positive-path counterpart to
+// TestSlaveIsReady_LoopbackMasterHostNeverReady: with a master reachable at
+// a non-loopback address, SlaveIsReady works as intended. Skipped if this
+// machine has no non-loopback IPv4 address (see nonLoopbackIPv4).
+func TestSlaveIsReady_NonLoopbackMaster(t *testing.T) {
+	requireRedisServer(t)
+	ip, ok := nonLoopbackIPv4()
+	if !ok {
+		t.Skip("no non-loopback IPv4 address available on this machine")
+	}
+	port, err := findFreePort()
+	require.NoError(t, err)
+	master := startRedisProcessOnAddr(t, ip, port)
+	replica := startReplicaOf(t, master)
+	c := newTestClient()
+
+	ready := waitForCondition(t, 10*time.Second, func() bool {
+		ready, err := c.SlaveIsReady(replica.IP, strconv.Itoa(replica.Port), "")
+		return err == nil && ready
+	})
+	assert.True(t, ready, "replica of a non-loopback master should eventually report ready")
+}
+
+func TestGetReplicationInfo_Master(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+
+	// Make sure the replica has been discovered as connected before
+	// asserting on connected_slaves.
+	waitForCondition(t, 10*time.Second, func() bool {
+		info, err := c.GetReplicationInfo(env.master.IP, strconv.Itoa(env.master.Port), "")
+		return err == nil && info.ConnectedSlaves >= 1
+	})
+
+	info, err := c.GetReplicationInfo(env.master.IP, strconv.Itoa(env.master.Port), "")
+	require.NoError(t, err)
+	assert.Equal(t, "master", info.Role)
+	assert.GreaterOrEqual(t, info.ConnectedSlaves, 1)
+	assert.GreaterOrEqual(t, info.MasterReplOffset, int64(0))
+	assert.False(t, info.SyncInProgress)
+}
+
+func TestGetReplicationInfo_Replica(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+
+	var info *ReplicationInfo
+	waitForCondition(t, 10*time.Second, func() bool {
+		var err error
+		info, err = c.GetReplicationInfo(env.replica.IP, strconv.Itoa(env.replica.Port), "")
+		return err == nil && info.MasterLinkStatus == "up"
+	})
+
+	require.NotNil(t, info)
+	assert.Equal(t, "slave", info.Role)
+	assert.Equal(t, env.master.IP, info.MasterHost)
+	assert.Equal(t, strconv.Itoa(env.master.Port), info.MasterPort)
+	assert.Equal(t, "up", info.MasterLinkStatus)
+	assert.False(t, info.SyncInProgress)
+	assert.GreaterOrEqual(t, info.SlaveReplOffset, int64(0))
+}
+
+// ---------------------------------------------------------------------
+// MakeMaster / MakeSlaveOf / MakeSlaveOfWithPort
+// (dedicated throwaway topologies - these mutate replication state)
+// ---------------------------------------------------------------------
+
+func TestMakeMaster(t *testing.T) {
+	requireRedisServer(t)
+	master := startRedisProcess(t)
+	replica := startReplicaOf(t, master)
+	c := newTestClient()
+
+	// Wait for the replica to actually become a slave before flipping it
+	// back, so the test exercises a real slave->master transition.
+	waitForCondition(t, 5*time.Second, func() bool {
+		isMaster, err := c.IsMaster(replica.IP, strconv.Itoa(replica.Port), "")
+		return err == nil && !isMaster
+	})
+
+	err := c.MakeMaster(replica.IP, strconv.Itoa(replica.Port), "")
+	require.NoError(t, err)
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		isMaster, err := c.IsMaster(replica.IP, strconv.Itoa(replica.Port), "")
+		return err == nil && isMaster
+	})
+	isMaster, err := c.IsMaster(replica.IP, strconv.Itoa(replica.Port), "")
+	require.NoError(t, err)
+	assert.True(t, isMaster)
+}
+
+// TestMakeSlaveOfWithPort_SamePortDifferentIP is the positive-path test for
+// MakeSlaveOfWithPort, using two independently-addressable instances that
+// happen to share one port number - the real-world shape (distinct pod IPs,
+// identical configured Redis port) that MakeSlaveOfWithPort's connection
+// logic actually requires. See the comment on
+// TestMakeSlaveOfWithPort_MismatchedTargetPort for why this matters and is
+// tested separately from the mismatched-port case. Skipped if this machine
+// has no non-loopback IPv4 address.
+func TestMakeSlaveOfWithPort_SamePortDifferentIP(t *testing.T) {
+	requireRedisServer(t)
+	otherIP, ok := nonLoopbackIPv4()
+	if !ok {
+		t.Skip("no non-loopback IPv4 address available on this machine")
+	}
+	port, err := findFreePort()
+	require.NoError(t, err)
+
+	a := startRedisProcessOnAddr(t, testLoopbackIP, port)
+	b := startRedisProcessOnAddr(t, otherIP, port)
+	c := newTestClient()
+
+	// Sanity check: both start out as independent masters.
+	isMaster, err := c.IsMaster(a.IP, strconv.Itoa(a.Port), "")
+	require.NoError(t, err)
+	require.True(t, isMaster)
+
+	err = c.MakeSlaveOfWithPort(a.IP, b.IP, strconv.Itoa(b.Port), "")
+	require.NoError(t, err)
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		masterOf, err := c.GetSlaveOf(a.IP, strconv.Itoa(a.Port), "")
+		return err == nil && masterOf == b.IP
+	})
+	masterOf, err := c.GetSlaveOf(a.IP, strconv.Itoa(a.Port), "")
+	require.NoError(t, err)
+	assert.Equal(t, b.IP, masterOf)
+
+	linkUp := waitForCondition(t, 10*time.Second, func() bool {
+		info, err := c.GetReplicationInfo(a.IP, strconv.Itoa(a.Port), "")
+		return err == nil && info.MasterLinkStatus == "up"
+	})
+	assert.True(t, linkUp)
+}
+
+// TestMakeSlaveOfWithPort_MismatchedTargetPort documents a real bug found
+// while building this test suite (not fixed here, per instructions - see
+// the task summary for the full report):
+//
+// MakeSlaveOfWithPort(ip, masterIP, masterPort, password) connects to the
+// *target* redis instance (the one it's about to issue SLAVEOF against) at
+// `net.JoinHostPort(ip, masterPort)` - i.e. it uses the *master's* port to
+// reach the target, with no separate parameter for the target's own port.
+// That's only correct when the target and the master happen to listen on
+// the same port number (true in this operator's normal deployment model,
+// where every managed Redis instance uses one shared configured port across
+// different pod IPs - see the SamePortDifferentIP test above for that
+// case). When the target's actual port differs from the master's port, this
+// silently does the wrong thing rather than failing loudly:
+//
+// Here `a` (the intended target) and `b` (the intended master) share the
+// same IP (both loopback) but listen on *different* ports. Calling
+// MakeSlaveOfWithPort(a.IP, b.IP, b.Port, "") computes the connection
+// address as (a.IP, b.Port) - since a.IP == b.IP, that address actually
+// belongs to `b`'s own server, not `a`'s. The client ends up connected to
+// `b` and issues `SLAVEOF b.IP b.Port` *to b itself*. Real Redis accepts
+// `SLAVEOF <self>` without error (confirmed manually against 7.0.15) and
+// becomes a slave of itself with master_link_status permanently "down" -
+// so the call returns a misleading nil error, `b` is left in a broken
+// self-replicating state, and `a` (the actual intended target) is never
+// contacted at all and remains an untouched master.
+func TestMakeSlaveOfWithPort_MismatchedTargetPort(t *testing.T) {
+	requireRedisServer(t)
+	a := startRedisProcess(t)
+	b := startRedisProcess(t)
+	c := newTestClient()
+	require.NotEqual(t, a.Port, b.Port, "test setup requires distinct ports to reproduce the bug")
+
+	err := c.MakeSlaveOfWithPort(a.IP, b.IP, strconv.Itoa(b.Port), "")
+	require.NoError(t, err, "the call itself does not surface an error - that's the point of this bug")
+
+	// `a`, the intended target, was never actually reached.
+	masterOf, err := c.GetSlaveOf(a.IP, strconv.Itoa(a.Port), "")
+	require.NoError(t, err)
+	assert.Empty(t, masterOf, "the intended target should be untouched, still a master")
+
+	// `b` was told to replicate from itself instead.
+	waitForCondition(t, 2*time.Second, func() bool {
+		masterOf, err := c.GetSlaveOf(b.IP, strconv.Itoa(b.Port), "")
+		return err == nil && masterOf == b.IP
+	})
+	masterOf, err = c.GetSlaveOf(b.IP, strconv.Itoa(b.Port), "")
+	require.NoError(t, err)
+	assert.Equal(t, b.IP, masterOf, "the master ends up pointed at itself instead of the target being reconfigured")
+}
+
+// TestMakeSlaveOf covers the MakeSlaveOf convenience wrapper, which hardcodes
+// the master port to redisPort ("6379") rather than accepting one - see
+// MakeSlaveOfWithPort. Like TestMakeSlaveOfWithPort_SamePortDifferentIP, it
+// needs the target and master on the same port at different IPs for
+// MakeSlaveOfWithPort's connection-address logic to reach the right
+// instance (see TestMakeSlaveOfWithPort_MismatchedTargetPort). Skipped if
+// this machine has no non-loopback IPv4 address, or if port 6379 is
+// already in use.
+func TestMakeSlaveOf(t *testing.T) {
+	requireRedisServer(t)
+	otherIP, ok := nonLoopbackIPv4()
+	if !ok {
+		t.Skip("no non-loopback IPv4 address available on this machine")
+	}
+	if !isPortFree(t, testLoopbackIP, 6379) || !isPortFree(t, otherIP, 6379) {
+		t.Skip("port 6379 is already in use on this machine; skipping MakeSlaveOf (hardcoded redisPort) test")
+	}
+
+	master := startRedisProcessOnAddr(t, otherIP, 6379)
+	slave := startRedisProcessOnAddr(t, testLoopbackIP, 6379)
+	c := newTestClient()
+
+	err := c.MakeSlaveOf(slave.IP, master.IP, "")
+	require.NoError(t, err)
+
+	waitForCondition(t, 5*time.Second, func() bool {
+		masterOf, err := c.GetSlaveOf(slave.IP, strconv.Itoa(slave.Port), "")
+		return err == nil && masterOf == master.IP
+	})
+	masterOf, err := c.GetSlaveOf(slave.IP, strconv.Itoa(slave.Port), "")
+	require.NoError(t, err)
+	assert.Equal(t, master.IP, masterOf)
+}
+
+func isPortFree(t *testing.T, ip string, port int) bool {
+	t.Helper()
+	l, err := net.Listen("tcp", net.JoinHostPort(ip, strconv.Itoa(port)))
+	if err != nil {
+		return false
+	}
+	_ = l.Close()
+	return true
+}
+
+// ---------------------------------------------------------------------
+// SetCustomRedisConfig
+// ---------------------------------------------------------------------
+
+func TestSetCustomRedisConfig_Basic(t *testing.T) {
+	requireRedisServer(t)
+	r := startRedisProcess(t)
+	c := newTestClient()
+
+	err := c.SetCustomRedisConfig(r.IP, strconv.Itoa(r.Port), []string{"maxmemory-policy allkeys-lru"}, "")
+	require.NoError(t, err)
+
+	rc := rediscli.NewClient(&rediscli.Options{Addr: r.Addr()})
+	defer func() { _ = rc.Close() }()
+	res, err := rc.ConfigGet(bgCtx(), "maxmemory-policy").Result()
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+	assert.Equal(t, "allkeys-lru", res[1])
+}
+
+// TestSetCustomRedisConfig_EmptyValue covers the `config set save ""` case
+// called out explicitly in a comment in SetCustomRedisConfig.
+func TestSetCustomRedisConfig_EmptyValue(t *testing.T) {
+	requireRedisServer(t)
+	r := startRedisProcess(t)
+	c := newTestClient()
+
+	err := c.SetCustomRedisConfig(r.IP, strconv.Itoa(r.Port), []string{`save ""`}, "")
+	require.NoError(t, err)
+
+	rc := rediscli.NewClient(&rediscli.Options{Addr: r.Addr()})
+	defer func() { _ = rc.Close() }()
+	res, err := rc.ConfigGet(bgCtx(), "save").Result()
+	require.NoError(t, err)
+	require.Len(t, res, 2)
+	assert.Equal(t, "", res[1])
+}
+
+func TestSetCustomRedisConfig_Malformed(t *testing.T) {
+	requireRedisServer(t)
+	r := startRedisProcess(t)
+	c := newTestClient()
+
+	err := c.SetCustomRedisConfig(r.IP, strconv.Itoa(r.Port), []string{"onewordonly"}, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "malformed")
+}
+
+// TestSetCustomRedisConfig_ACLFile documents a real bug found while building
+// this test suite (not fixed here, per instructions - see the task summary
+// for the full report):
+//
+// `CONFIG SET aclfile <path>` is an *immutable* config in real Redis (7.0.15,
+// confirmed here; Redis docs mark aclfile as requiring a server restart to
+// change) - the server rejects it with "ERR CONFIG SET failed... can't set
+// immutable config", regardless of whether the value being set matches the
+// aclfile Redis was already started with. This is true even when the target
+// file exists.
+//
+// client.go's SetCustomRedisConfig loop calls applyRedisConfig (CONFIG SET)
+// for every parameter *before* checking whether it was "aclfile" and
+// triggering applyACLLoad (ACL LOAD). Against real Redis, the CONFIG SET
+// aclfile call above fails and SetCustomRedisConfig returns that error
+// immediately - meaning applyACLLoad is unreachable dead code whenever the
+// custom config list contains an "aclfile" line, and RedisFailover CRs that
+// set `spec.redis.customConfig` to include an aclfile line (the exact
+// scenario commit 8add5ac "Fix aclfile in CustomConfig silently not loading
+// ACL users" was meant to fix) will always fail this call in practice.
+func TestSetCustomRedisConfig_ACLFile(t *testing.T) {
+	requireRedisServer(t)
+	dir := t.TempDir()
+	aclPath := dir + "/users.acl"
+	require.NoError(t, os.WriteFile(aclPath, []byte("user testuser on >testpass ~* +@all\n"), 0o600))
+
+	// Start with the aclfile already configured at boot, which is the only
+	// way Redis will accept it at all.
+	r := startRedisProcess(t, "--aclfile", aclPath)
+	c := newTestClient()
+
+	err := c.SetCustomRedisConfig(r.IP, strconv.Itoa(r.Port), []string{"aclfile " + aclPath}, "")
+	require.Error(t, err, "CONFIG SET aclfile is immutable in real Redis; this documents current (buggy) behavior, see comment above")
+	assert.Contains(t, err.Error(), "immutable")
+}
+
+// ---------------------------------------------------------------------
+// Sentinel: GetSentinelMonitor / GetNumberSentinelsInMemory /
+// GetNumberSentinelSlavesInMemory (shared read-only sentinel)
+// ---------------------------------------------------------------------
+
+func TestGetSentinelMonitor(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+
+	ip, port, err := c.GetSentinelMonitor(env.sentinel.IP)
+	require.NoError(t, err)
+	assert.Equal(t, env.master.IP, ip)
+	assert.Equal(t, strconv.Itoa(env.master.Port), port)
+}
+
+func TestGetNumberSentinelsInMemory(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+
+	n, err := c.GetNumberSentinelsInMemory(env.sentinel.IP)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n, "only one sentinel process is running, monitoring itself")
+}
+
+func TestGetNumberSentinelSlavesInMemory(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+
+	// Sentinel discovers replicas by periodically polling INFO on the
+	// master it monitors; this can take several seconds after the replica
+	// first attaches.
+	ok := waitForCondition(t, 20*time.Second, func() bool {
+		n, err := c.GetNumberSentinelSlavesInMemory(env.sentinel.IP)
+		return err == nil && n >= 1
+	})
+	require.True(t, ok, "sentinel should eventually discover the replica")
+
+	n, err := c.GetNumberSentinelSlavesInMemory(env.sentinel.IP)
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, n)
+}
+
+// TestGetNumberSentinelsInMemory_NotMonitoringAnything temporarily strips
+// the shared sentinel's only monitored master (SENTINEL REMOVE) rather than
+// starting a second sentinel process - see newSentinelProcessOnPort's doc
+// comment for why there can only be one. It restores the shared sentinel's
+// normal monitoring state via t.Cleanup so later tests aren't affected.
+func TestGetNumberSentinelsInMemory_NotMonitoringAnything(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+	t.Cleanup(func() { restoreSharedSentinel(t, env) })
+
+	rc := rediscli.NewSentinelClient(&rediscli.Options{Addr: env.sentinel.Addr()})
+	defer func() { _ = rc.Close() }()
+	removeCmd := rediscli.NewBoolCmd(bgCtx(), "SENTINEL", "REMOVE", masterName)
+	require.NoError(t, rc.Process(bgCtx(), removeCmd))
+	_, err := removeCmd.Result()
+	require.NoError(t, err)
+
+	// A sentinel monitoring nothing has no "status=" line to report ok for,
+	// so isSentinelReady should reject it.
+	_, err = c.GetNumberSentinelsInMemory(env.sentinel.IP)
+	assert.Error(t, err)
+}
+
+// ---------------------------------------------------------------------
+// MonitorRedisWithPort / SetCustomSentinelConfig / ResetSentinel /
+// SentinelCheckQuorum
+//
+// These all mutate sentinel state, but per newSentinelProcessOnPort's doc
+// comment there can only be one sentinel process reachable through Client
+// at a time (it always connects to the hardcoded sentinelPort). So each of
+// these repoints the single shared sentinel at its own dedicated throwaway
+// master (rather than starting a second sentinel process) and restores it
+// back to the shared master via t.Cleanup. Go runs tests within a package
+// sequentially by default (none of these call t.Parallel), so this is safe.
+// ---------------------------------------------------------------------
+
+// TestMonitorRedis covers the MonitorRedis convenience wrapper, which
+// hardcodes the monitored master's port to redisPort ("6379") when calling
+// MonitorRedisWithPort. Unlike MakeSlaveOf's use of the same constant, this
+// doesn't require anything actually listening on 6379: the port is only
+// ever used as a text argument to `SENTINEL MONITOR`, never as a connection
+// address (MonitorRedisWithPort always connects to the sentinel itself, on
+// sentinelPort), so this can safely run even where port 6379 is unavailable
+// or already in use.
+func TestMonitorRedis(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+	t.Cleanup(func() { restoreSharedSentinel(t, env) })
+
+	err := c.MonitorRedis(env.sentinel.IP, testLoopbackIP, "1", "")
+	require.NoError(t, err)
+
+	ip, port, err := c.GetSentinelMonitor(env.sentinel.IP)
+	require.NoError(t, err)
+	assert.Equal(t, testLoopbackIP, ip)
+	assert.Equal(t, redisPort, port)
+}
+
+func TestMonitorRedisWithPort(t *testing.T) {
+	env := getSharedEnv(t)
+	master := startRedisProcess(t)
+	c := newTestClient()
+	t.Cleanup(func() { restoreSharedSentinel(t, env) })
+
+	err := c.MonitorRedisWithPort(env.sentinel.IP, master.IP, strconv.Itoa(master.Port), "1", "")
+	require.NoError(t, err)
+
+	ip, port, err := c.GetSentinelMonitor(env.sentinel.IP)
+	require.NoError(t, err)
+	assert.Equal(t, master.IP, ip)
+	assert.Equal(t, strconv.Itoa(master.Port), port)
+}
+
+func TestMonitorRedisWithPort_WithPassword(t *testing.T) {
+	env := getSharedEnv(t)
+	master := startRedisProcess(t)
+	c := newTestClient()
+	t.Cleanup(func() { restoreSharedSentinel(t, env) })
+
+	// MonitorRedisWithPort unconditionally issues `SENTINEL SET mymaster
+	// auth-pass <password>` when a password is given; this only asserts
+	// that call itself succeeds against sentinel (it does not require the
+	// master to actually be configured with a matching requirepass).
+	err := c.MonitorRedisWithPort(env.sentinel.IP, master.IP, strconv.Itoa(master.Port), "1", "s3cr3t")
+	require.NoError(t, err)
+}
+
+func TestSetCustomSentinelConfig(t *testing.T) {
+	env := getSharedEnv(t)
+	master := startRedisProcess(t)
+	c := newTestClient()
+	t.Cleanup(func() { restoreSharedSentinel(t, env) })
+	pointSharedSentinelAt(t, env.sentinel, master.IP, master.Port, 1)
+
+	err := c.SetCustomSentinelConfig(env.sentinel.IP, []string{"down-after-milliseconds 12345"})
+	require.NoError(t, err)
+
+	rc := rediscli.NewSentinelClient(&rediscli.Options{Addr: env.sentinel.Addr()})
+	defer func() { _ = rc.Close() }()
+	res, err := rc.Master(bgCtx(), masterName).Result()
+	require.NoError(t, err)
+	assert.Equal(t, "12345", res["down-after-milliseconds"])
+}
+
+func TestResetSentinel(t *testing.T) {
+	env := getSharedEnv(t)
+	master := startRedisProcess(t)
+	c := newTestClient()
+	t.Cleanup(func() { restoreSharedSentinel(t, env) })
+	pointSharedSentinelAt(t, env.sentinel, master.IP, master.Port, 1)
+
+	err := c.ResetSentinel(env.sentinel.IP)
+	require.NoError(t, err)
+}
+
+func TestSentinelCheckQuorum_OK(t *testing.T) {
+	env := getSharedEnv(t)
+	c := newTestClient()
+
+	err := c.SentinelCheckQuorum(env.sentinel.IP)
+	assert.NoError(t, err)
+}
+
+// TestSentinelCheckQuorum_NoQuorum documents a real bug found while building
+// this test suite (not fixed here, per instructions - see the task summary
+// for the full report):
+//
+// Real Sentinel's CKQUORUM reply for the NOQUORUM case comes back as a RESP
+// *error* reply (confirmed here against real Redis 7.0.15: `redis-cli
+// --no-raw` shows `(error) NOQUORUM ...`), not as a successful string reply
+// whose text happens to start with the literal characters "(error)". Since
+// go-redis's SentinelClient.CkQuorum uses a StringCmd, that RESP error
+// becomes cmd.Err()/the err returned by cmd.Result() - so
+// client.go's SentinelCheckQuorum takes its `if err != nil { ... return err
+// }` branch immediately.
+//
+// The subsequent code - `s := strings.Split(res, " ")` followed by `if
+// status == "(error)" && quorum == "NOQUORUM"` - can therefore never
+// execute on a real NOQUORUM response: `res` is only non-empty when err is
+// nil, i.e. only for the OK case, so status will always be "OK" whenever
+// that branch is reached. In other words, the code's own intended NOQUORUM
+// handling (returning `errors.New("quorum Not available")`) is dead code;
+// what actually gets returned to callers today is the raw driver error
+// (whose message happens to also mention NOQUORUM, so callers checking
+// err != nil for failure still work correctly - this is a
+// dead-code/messaging bug, not a functional regression for existing
+// callers as far as we can tell).
+func TestSentinelCheckQuorum_NoQuorum(t *testing.T) {
+	env := getSharedEnv(t)
+	master := startRedisProcess(t)
+	c := newTestClient()
+	t.Cleanup(func() { restoreSharedSentinel(t, env) })
+
+	// Ask sentinel to monitor with a quorum of 2, which a single sentinel
+	// process can never satisfy.
+	err := c.MonitorRedisWithPort(env.sentinel.IP, master.IP, strconv.Itoa(master.Port), "2", "")
+	require.NoError(t, err)
+
+	err = c.SentinelCheckQuorum(env.sentinel.IP)
+	require.Error(t, err, "CKQUORUM should fail when quorum exceeds the number of known sentinels")
+}

--- a/service/redis/testutil_test.go
+++ b/service/redis/testutil_test.go
@@ -1,0 +1,449 @@
+package redis
+
+// This file provides a small test harness that spins up real redis-server
+// (and redis-server --sentinel) subprocesses so the tests in client_test.go
+// exercise the actual Redis/Sentinel wire protocol instead of a mock RESP
+// server. A mock would let us assert whatever we assumed the protocol does;
+// what bit the operator in production was an assumption about real
+// redis/sentinel behaviour (see client_test.go's CKQUORUM and aclfile tests)
+// that turned out to be wrong, so these tests talk to the real binaries.
+//
+// All tests here skip (t.Skip), not fail, when redis-server is not on PATH -
+// see requireRedisServer. CI installs redis-server explicitly so it always
+// runs there; this keeps `go test ./...` usable on a machine without it.
+//
+// A small, fixed set of long-lived processes (one master, one replica of it,
+// one sentinel monitoring it) is started once for the whole test binary run
+// in TestMain and shared read-only across tests - see sharedEnv. Tests that
+// need to mutate replication topology start their own dedicated throwaway
+// redis-server processes instead (via startRedisProcess), cleaned up
+// per-test via t.Cleanup. Tests that need to mutate sentinel state repoint
+// and restore the single shared sentinel process instead of starting their
+// own - see newSentinelProcessOnPort's doc comment for why there can only
+// ever be one.
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	rediscli "github.com/go-redis/redis/v8"
+)
+
+const testLoopbackIP = "127.0.0.1"
+
+// bgCtx is a tiny convenience wrapper so test helpers read a little less
+// noisily than repeating context.Background() everywhere.
+func bgCtx() context.Context {
+	return context.Background()
+}
+
+// requireRedisServer skips the calling test when redis-server isn't
+// available on PATH, so `go test ./...` keeps working on a machine that
+// doesn't have Redis installed.
+func requireRedisServer(t *testing.T) {
+	t.Helper()
+	if !hasRedisServer() {
+		t.Skip("redis-server not found on PATH; skipping test that needs a real redis-server subprocess")
+	}
+}
+
+func hasRedisServer() bool {
+	_, err := exec.LookPath("redis-server")
+	return err == nil
+}
+
+// redisProc represents a running redis-server (plain or --sentinel) test
+// subprocess, bound to an isolated temp working directory.
+type redisProc struct {
+	IP   string
+	Port int
+	dir  string
+	cmd  *exec.Cmd
+}
+
+func (p *redisProc) Addr() string {
+	return net.JoinHostPort(p.IP, strconv.Itoa(p.Port))
+}
+
+// findFreePort asks the OS for a currently-unused TCP port by briefly
+// binding to :0 and releasing it. redis-server itself doesn't support
+// OS-assigned ports, so callers pass the returned port to redis-server and
+// retry in the unlikely case something else grabs it first.
+func findFreePort() (int, error) {
+	l, err := net.Listen("tcp", testLoopbackIP+":0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = l.Close() }()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// waitForPingErr polls PING against proc until it succeeds or the timeout
+// elapses. It also detects an early process exit (e.g. a port bind failure)
+// so callers can retry with a different port instead of waiting out the
+// full timeout.
+func waitForPingErr(proc *redisProc, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	rc := rediscli.NewClient(&rediscli.Options{Addr: proc.Addr(), DialTimeout: 200 * time.Millisecond})
+	defer func() { _ = rc.Close() }()
+	for time.Now().Before(deadline) {
+		if proc.cmd.ProcessState != nil {
+			return fmt.Errorf("redis-server exited early (dir=%s)", proc.dir)
+		}
+		if err := rc.Ping(bgCtx()).Err(); err == nil {
+			return nil
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for redis-server to respond to PING at %s", proc.Addr())
+}
+
+func killProc(proc *redisProc) {
+	if proc == nil || proc.cmd == nil || proc.cmd.Process == nil {
+		return
+	}
+	_ = proc.cmd.Process.Kill()
+	_, _ = proc.cmd.Process.Wait()
+}
+
+// newRedisProcess starts a plain (non-sentinel) redis-server in its own temp
+// dir, with persistence disabled for speed and to avoid leaving artifacts
+// behind, retrying with a fresh port on bind failure. It has no *testing.T
+// dependency so it can be used both from per-test helpers and from
+// TestMain for the long-lived shared environment.
+func newRedisProcess(extraArgs ...string) (*redisProc, error) {
+	var lastErr error
+	for attempt := 0; attempt < 5; attempt++ {
+		dir, err := os.MkdirTemp("", "redis-operator-test-redis-")
+		if err != nil {
+			return nil, fmt.Errorf("mkdir temp dir: %w", err)
+		}
+		port, err := findFreePort()
+		if err != nil {
+			_ = os.RemoveAll(dir)
+			return nil, fmt.Errorf("find free port: %w", err)
+		}
+		args := []string{
+			"--port", strconv.Itoa(port),
+			"--daemonize", "no",
+			"--save", "",
+			"--appendonly", "no",
+			"--bind", testLoopbackIP,
+			"--protected-mode", "no",
+			"--dir", dir,
+			"--logfile", filepath.Join(dir, "log.txt"),
+		}
+		args = append(args, extraArgs...)
+		cmd := exec.Command("redis-server", args...)
+		if err := cmd.Start(); err != nil {
+			_ = os.RemoveAll(dir)
+			return nil, fmt.Errorf("start redis-server: %w", err)
+		}
+		proc := &redisProc{IP: testLoopbackIP, Port: port, dir: dir, cmd: cmd}
+		go func() { _ = cmd.Wait() }()
+		if err := waitForPingErr(proc, 5*time.Second); err != nil {
+			lastErr = err
+			killProc(proc)
+			_ = os.RemoveAll(dir)
+			continue
+		}
+		return proc, nil
+	}
+	return nil, fmt.Errorf("could not start redis-server after retries: %w", lastErr)
+}
+
+// newSentinelProcessOnPort starts redis-server in --sentinel mode bound to
+// an exact, caller-chosen port. Sentinel refuses to start without a config
+// file it can rewrite to disk, so one is written into an isolated temp dir
+// first. extraConfLines are appended to that config file verbatim (e.g.
+// "sentinel monitor mymaster 127.0.0.1 6379 1"). Like newRedisProcess, this
+// has no *testing.T dependency, so it's usable from TestMain.
+//
+// Every Sentinel-related method on Client (GetSentinelMonitor,
+// GetNumberSentinelsInMemory, MonitorRedisWithPort, SentinelCheckQuorum,
+// SetCustomSentinelConfig, ResetSentinel, ...) connects to the *hardcoded*
+// sentinelPort constant rather than to any port passed in or discovered -
+// confirmed by reading client.go, where every Sentinel function builds its
+// Addr as `net.JoinHostPort(ip, sentinelPort)`. Unlike the plain-Redis
+// methods (which all take an explicit port parameter), there is no way to
+// reach a test sentinel on any other port through the Client interface.
+// That's why this package starts exactly one sentinel process, on
+// sentinelPort, for the whole test binary run (see TestMain) instead of a
+// dedicated throwaway sentinel per test: only one process can bind
+// 127.0.0.1:<sentinelPort> at a time. Tests that need a differently
+// configured sentinel repoint and restore this single shared process - see
+// pointSharedSentinelAt.
+func newSentinelProcessOnPort(port int, extraConfLines ...string) (*redisProc, error) {
+	dir, err := os.MkdirTemp("", "redis-operator-test-sentinel-")
+	if err != nil {
+		return nil, fmt.Errorf("mkdir temp dir: %w", err)
+	}
+	confPath := filepath.Join(dir, "sentinel.conf")
+	conf := fmt.Sprintf("port %d\ndir %s\nsentinel resolve-hostnames no\n", port, dir)
+	for _, line := range extraConfLines {
+		conf += line + "\n"
+	}
+	if err := os.WriteFile(confPath, []byte(conf), 0o600); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("write sentinel config: %w", err)
+	}
+	cmd := exec.Command("redis-server", confPath, "--sentinel",
+		"--daemonize", "no",
+		"--logfile", filepath.Join(dir, "log.txt"),
+	)
+	if err := cmd.Start(); err != nil {
+		_ = os.RemoveAll(dir)
+		return nil, fmt.Errorf("start redis-server --sentinel: %w", err)
+	}
+	proc := &redisProc{IP: testLoopbackIP, Port: port, dir: dir, cmd: cmd}
+	go func() { _ = cmd.Wait() }()
+	if err := waitForPingErr(proc, 5*time.Second); err != nil {
+		killProc(proc)
+		_ = os.RemoveAll(dir)
+		return nil, err
+	}
+	return proc, nil
+}
+
+// startRedisProcess is the per-test wrapper around newRedisProcess: it fails
+// the test on error and registers cleanup via t.Cleanup.
+func startRedisProcess(t *testing.T, extraArgs ...string) *redisProc {
+	t.Helper()
+	proc, err := newRedisProcess(extraArgs...)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	t.Cleanup(func() {
+		killProc(proc)
+		_ = os.RemoveAll(proc.dir)
+	})
+	return proc
+}
+
+// startRedisProcessOnAddr starts a plain redis-server bound to an exact
+// caller-chosen IP and port. Used together with nonLoopbackIPv4 to set up
+// two independently-addressable instances sharing the same port number
+// (mirroring how distinct pods in a real deployment share one Redis port),
+// which MakeSlaveOfWithPort's connection-address logic actually requires -
+// see the comment on TestMakeSlaveOfWithPort_MismatchedTargetPort.
+func startRedisProcessOnAddr(t *testing.T, ip string, port int, extraArgs ...string) *redisProc {
+	t.Helper()
+	dir := t.TempDir()
+	args := []string{
+		"--port", strconv.Itoa(port),
+		"--daemonize", "no",
+		"--save", "",
+		"--appendonly", "no",
+		"--bind", ip,
+		"--protected-mode", "no",
+		"--dir", dir,
+		"--logfile", filepath.Join(dir, "log.txt"),
+	}
+	args = append(args, extraArgs...)
+	cmd := exec.Command("redis-server", args...)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed to start redis-server on %s:%d: %v", ip, port, err)
+	}
+	proc := &redisProc{IP: ip, Port: port, dir: dir, cmd: cmd}
+	go func() { _ = cmd.Wait() }()
+	if err := waitForPingErr(proc, 5*time.Second); err != nil {
+		killProc(proc)
+		t.Fatalf("redis-server did not come up on %s:%d: %v", ip, port, err)
+	}
+	t.Cleanup(func() { killProc(proc) })
+	return proc
+}
+
+// nonLoopbackIPv4 returns a non-loopback IPv4 address configured on this
+// machine, if any, and true - or ("", false) if none is found. It exists
+// so a couple of tests can set up two independently-addressable Redis
+// instances (needed to exercise MakeSlaveOfWithPort correctly, and to avoid
+// a documented client.go quirk where a replica whose master_host happens to
+// be exactly "127.0.0.1" is never reported ready - see
+// TestSlaveIsReady_LoopbackMasterHostNeverReady). Every CI runner and
+// ordinary dev machine has one (e.g. eth0), but this skips gracefully
+// rather than failing on an unusual sandboxed network namespace with only
+// loopback.
+func nonLoopbackIPv4() (string, bool) {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return "", false
+	}
+	for _, a := range addrs {
+		ipNet, ok := a.(*net.IPNet)
+		if !ok {
+			continue
+		}
+		ip4 := ipNet.IP.To4()
+		if ip4 == nil || ip4.IsLoopback() {
+			continue
+		}
+		return ip4.String(), true
+	}
+	return "", false
+}
+
+// startReplicaOf starts a fresh redis-server and points it at master via
+// REPLICAOF, returning once the process is up (not once replication is
+// synced - callers that need a synced/"up" link should poll, e.g. via
+// waitForCondition on SlaveIsReady or GetReplicationInfo).
+func startReplicaOf(t *testing.T, master *redisProc) *redisProc {
+	t.Helper()
+	return startRedisProcess(t, "--replicaof", master.IP, strconv.Itoa(master.Port))
+}
+
+// waitForCondition polls cond until it returns true or the timeout elapses.
+func waitForCondition(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return cond()
+}
+
+// sharedEnv holds the small, fixed set of long-lived redis/sentinel
+// processes shared read-only across tests that don't mutate topology or
+// sentinel state, so we don't pay subprocess-startup cost per test case.
+// It's started once in TestMain (not via a per-test t.Cleanup-guarded
+// sync.Once - the processes must outlive whichever individual test happens
+// to run first) and torn down after all tests in the package finish.
+// Tests that mutate replication topology (MakeMaster, MakeSlaveOf, ...) must
+// start their own dedicated throwaway redis-server processes instead of
+// touching master/replica here. Tests that mutate sentinel state
+// (SetCustomSentinelConfig, MonitorRedisWithPort, ResetSentinel, the
+// NOQUORUM scenario, ...) repoint and restore the shared sentinel itself -
+// see pointSharedSentinelAt/restoreSharedSentinel.
+type sharedEnv struct {
+	master   *redisProc
+	replica  *redisProc
+	sentinel *redisProc
+}
+
+var sharedEnvVal *sharedEnv
+
+// TestMain starts the shared environment once (if redis-server is
+// available) before any test runs, and tears it down after all tests in the
+// package complete - see sharedEnv's doc comment for why this can't be a
+// lazy sync.Once initialized from inside an individual test.
+func TestMain(m *testing.M) {
+	var cleanups []func()
+	cleanupAll := func() {
+		for i := len(cleanups) - 1; i >= 0; i-- {
+			cleanups[i]()
+		}
+	}
+
+	if hasRedisServer() {
+		master, err := newRedisProcess()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to start shared test master: %v\n", err)
+			os.Exit(1)
+		}
+		cleanups = append(cleanups, func() { killProc(master); _ = os.RemoveAll(master.dir) })
+
+		replica, err := newRedisProcess("--replicaof", master.IP, strconv.Itoa(master.Port))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to start shared test replica: %v\n", err)
+			cleanupAll()
+			os.Exit(1)
+		}
+		cleanups = append(cleanups, func() { killProc(replica); _ = os.RemoveAll(replica.dir) })
+
+		// Sentinel-related Client methods hardcode sentinelPort as the port
+		// they connect to (see newSentinelProcessOnPort's doc comment), so
+		// the shared test sentinel must bind exactly that port.
+		fixedSentinelPort, err := strconv.Atoi(sentinelPort)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "client.go's sentinelPort constant %q is not numeric: %v\n", sentinelPort, err)
+			cleanupAll()
+			os.Exit(1)
+		}
+		sentinel, err := newSentinelProcessOnPort(fixedSentinelPort,
+			fmt.Sprintf("sentinel monitor mymaster %s %d 1", master.IP, master.Port),
+			"sentinel down-after-milliseconds mymaster 2000",
+		)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to start shared test sentinel on port %d: %v\n", fixedSentinelPort, err)
+			cleanupAll()
+			os.Exit(1)
+		}
+		cleanups = append(cleanups, func() { killProc(sentinel); _ = os.RemoveAll(sentinel.dir) })
+
+		// Wait for the replication link to come up so tests relying on
+		// master-side connected_slaves / sentinel-side slave discovery
+		// don't race the initial sync.
+		deadline := time.Now().Add(15 * time.Second)
+		for time.Now().Before(deadline) {
+			rc := rediscli.NewClient(&rediscli.Options{Addr: replica.Addr()})
+			info, err := rc.Info(bgCtx(), "replication").Result()
+			_ = rc.Close()
+			if err == nil && strings.Contains(info, redisLinkUp) {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		sharedEnvVal = &sharedEnv{master: master, replica: replica, sentinel: sentinel}
+	}
+
+	code := m.Run()
+	cleanupAll()
+	os.Exit(code)
+}
+
+// getSharedEnv returns the shared master/replica/sentinel environment
+// started in TestMain, skipping the calling test if redis-server wasn't
+// available (and so the shared environment was never started).
+func getSharedEnv(t *testing.T) *sharedEnv {
+	t.Helper()
+	requireRedisServer(t)
+	if sharedEnvVal == nil {
+		t.Fatal("shared redis/sentinel test environment failed to initialize (see TestMain output)")
+	}
+	return sharedEnvVal
+}
+
+// pointSharedSentinelAt repoints the single shared sentinel process (see
+// newSentinelProcessOnPort's doc comment for why there's only one) at the
+// given master/quorum via raw SENTINEL REMOVE+MONITOR, bypassing the
+// Client under test so setup/teardown for tests that aren't themselves
+// about MonitorRedisWithPort doesn't depend on it. It fails the test if the
+// commands don't succeed.
+func pointSharedSentinelAt(t *testing.T, sentinel *redisProc, masterIP string, masterPort int, quorum int) {
+	t.Helper()
+	rc := rediscli.NewSentinelClient(&rediscli.Options{Addr: sentinel.Addr()})
+	defer func() { _ = rc.Close() }()
+	// Best-effort removal of any existing "mymaster" entry, mirroring
+	// MonitorRedisWithPort's own "continue even if it fails" approach.
+	_ = rc.Process(bgCtx(), rediscli.NewBoolCmd(bgCtx(), "SENTINEL", "REMOVE", masterName))
+	cmd := rediscli.NewBoolCmd(bgCtx(), "SENTINEL", "MONITOR", masterName, masterIP, strconv.Itoa(masterPort), strconv.Itoa(quorum))
+	if err := rc.Process(bgCtx(), cmd); err != nil {
+		t.Fatalf("failed to point shared sentinel at %s:%d: %v", masterIP, masterPort, err)
+	}
+	if _, err := cmd.Result(); err != nil {
+		t.Fatalf("failed to point shared sentinel at %s:%d: %v", masterIP, masterPort, err)
+	}
+}
+
+// restoreSharedSentinel points the shared sentinel back at the shared
+// master with quorum 1, the state every read-only test expects to find it
+// in. Tests that repoint the shared sentinel elsewhere must register this
+// via t.Cleanup so later tests aren't affected - Go runs tests within a
+// package sequentially unless they call t.Parallel (none here do), so this
+// is safe as long as every mutating test restores what it changed.
+func restoreSharedSentinel(t *testing.T, env *sharedEnv) {
+	t.Helper()
+	pointSharedSentinelAt(t, env.sentinel, env.master.IP, env.master.Port, 1)
+}


### PR DESCRIPTION
Fixes # .

Changes proposed on the PR:
- Add `service/redis/testutil_test.go`: a harness that starts real `redis-server` / `redis-server --sentinel` subprocesses (not a mock RESP server) for tests to talk to.
- Add `service/redis/client_test.go`: 24 tests covering `IsMaster`, `GetSlaveOf`, `SlaveIsReady`, `GetReplicationInfo`, `MakeMaster`, `MakeSlaveOf`/`MakeSlaveOfWithPort`, `SetCustomRedisConfig` (including the `aclfile`/`ACL LOAD` path), `MonitorRedis`/`MonitorRedisWithPort`, `GetSentinelMonitor`, `GetNumberSentinelsInMemory`/`GetNumberSentinelSlavesInMemory`, `SetCustomSentinelConfig`, `ResetSentinel`, and `SentinelCheckQuorum`.
- Add a step to `.github/workflows/ci.yaml`'s `unit-test` job to `apt-get install redis-server`, **required** for these tests to actually run in CI (see below).

## Why this needed real redis-server, not a mock

`service/redis/client.go` had **zero** test coverage despite being the entire wire-protocol layer the operator uses to talk to Redis and Sentinel. This wasn't hypothetical: a recent sentinel-readiness fix required manually spinning up real `redis-server`/`redis-sentinel` in a throwaway shell to validate an assumption about `redis-cli`'s behavior, because there was no test harness to lean on — and the assumption turned out to be wrong. A mock RESP server would only ever validate whatever we assumed the protocol does; building this suite against real binaries surfaced several assumptions in `client.go` itself that turned out to be wrong (see "Bugs found" below) — exactly the kind of thing a mock would have hidden.

The harness (`testutil_test.go`):
- Starts one shared master + one replica of it + one sentinel (fixed on `sentinelPort`, see below) once per test binary run, shared read-only across tests that don't mutate state.
- Tests that mutate replication topology (`MakeMaster`, `MakeSlaveOf`, ...) start their own dedicated throwaway `redis-server` processes, cleaned up via `t.Cleanup`.
- Tests that mutate sentinel state repoint and restore the single shared sentinel (see below for why there can only be one).
- Uses isolated temp dirs per process, `--save ""`/`--appendonly no` for speed, dynamic port allocation with bind-failure retry, and kills subprocesses via `t.Cleanup`/`TestMain` teardown (verified no orphaned `redis-server` processes after runs, including under `-race`).
- **Skips gracefully** (`t.Skip`, not fail) when `redis-server` isn't on `PATH` — verified locally by running the suite with a `PATH` that excludes it: all 24 tests report `SKIP` and the package still passes.

## Why the CI workflow change is required

GitHub-hosted `ubuntu-latest` runners don't ship `redis-server`. Without installing it, these tests don't fail loudly — they silently skip (see above), giving false confidence that the package has been tested when it hasn't. The new step installs it before `make ci-unit-test-coverage` runs.

## How I validated it

All of this was run against a real `redis-server` (v7.0.15) in the sandbox, not just compiled:
- `go build ./...`, `go vet ./...` — clean.
- `golangci-lint run ./...` — 0 issues.
- `go test ./service/redis/... -v` — all 24 tests **pass** against real subprocesses (~16s), confirmed repeatable across multiple runs and clean under `-race`.
- `go test ./...` — full suite passes.
- `make ci-unit-test-coverage` (the exact command CI now runs) — passes, `service/redis` coverage: **71.5%** of statements.
- Re-ran with a `redis-server`-less `PATH` to confirm the skip path works.

## Bugs found while building this (not fixed here, per instructions — flagged in code comments too)

1. **`CONFIG SET aclfile` is immutable in real Redis** (confirmed against 7.0.15, both freshly-booted and boot-with-aclfile-already-set): it always errors with `can't set immutable config`. `SetCustomRedisConfig` calls `CONFIG SET` for every parameter, including `aclfile`, *before* checking whether to run `ACL LOAD` — so against real Redis, that call fails and the function returns early. `applyACLLoad` is therefore unreachable dead code today (0% coverage even with a dedicated test attempting to reach it), and the `ACL LOAD` fix from #105/commit `8add5ac` never actually executes when `spec.redis.customConfig` includes an `aclfile` line. See `TestSetCustomRedisConfig_ACLFile`.
2. **`SentinelCheckQuorum`'s NOQUORUM branch is dead code.** Real Sentinel's `CKQUORUM` NOQUORUM reply is a RESP *error*, not a successful string reply — confirmed via `redis-cli --no-raw`. go-redis's `CkQuorum` uses a `StringCmd`, so that error becomes `cmd.Err()`/the error from `.Result()`, meaning `client.go`'s `if err != nil { return err }` branch fires immediately. The subsequent `status == "(error)"` string check can never be reached (that string is a `redis-cli` display artifact, never present in the actual reply payload), so the intended `errors.New("quorum Not available")` is never returned — callers get the raw driver error instead. Not a functional regression (callers still see a non-nil error), but the intended messaging path is unreachable. See `TestSentinelCheckQuorum_NoQuorum`.
3. **`sentinelPort` is hardcoded to `"26379"`** in every Sentinel-related `Client` method — none of them take or honor a port parameter for the sentinel connection itself (only for command arguments, e.g. `MonitorRedisWithPort`'s master port). This shaped the harness (only one sentinel process can be reached through `Client` at a time) but is presumably intentional for this operator's fixed-port deployment model, so it's just documented, not flagged as a bug.
4. **`MakeSlaveOfWithPort` conflates the target's connection port with the master's port.** It connects to `net.JoinHostPort(ip, masterPort)` — i.e., it uses the *master's* port to reach the *target* instance, with no separate parameter for the target's own port. This is only correct when the target and master share the same port number (true in this operator's normal same-port-different-pod-IP deployment model — see `TestMakeSlaveOfWithPort_SamePortDifferentIP` for that working case). When they differ, the client silently connects to the wrong instance instead of erroring: `TestMakeSlaveOfWithPort_MismatchedTargetPort` reproduces this — the call returns `nil` error, the intended target is never touched, and the "master" ends up told to `SLAVEOF` itself (which real Redis accepts, leaving it stuck with `master_link_status:down` forever).

## Coverage by function (`service/redis`, 71.5% overall)

Well covered (70–100%): `New`, `isSentinelReady`, `ResetSentinel`, `GetSlaveOf`, `IsMaster`, `MonitorRedis`, `MonitorRedisWithPort`, `MakeMaster`, `MakeSlaveOf`, `MakeSlaveOfWithPort`, `GetSentinelMonitor`, `SetCustomSentinelConfig`, `SentinelCheckQuorum`, `SetCustomRedisConfig`, `applyRedisConfig`, `applySentinelConfig`, `getConfigParameters`, `SlaveIsReady`, `GetReplicationInfo`.

Partially covered: `GetNumberSentinelsInMemory`/`GetNumberSentinelSlavesInMemory` (65%/58% — the `nSentinels/nSlaves > 65536` guard branches aren't exercised, not practically reachable in a test), `getRedisError` (55% — only a couple of its string-matching branches are exercised).

Not reached: `applyACLLoad` (0% — genuinely unreachable via `SetCustomRedisConfig` against real Redis, see bug #1 above).

## Follow-up ideas (not done here, to keep this PR scoped)

- A mock/fault-injection layer for `getRedisError`'s NOAUTH/WRONGPASS/NOPERM/timeout branches, which are awkward to trigger with real Redis without extra setup (ACL users, TLS, etc.).
- Password-authenticated end-to-end tests (`requirepass` + `MakeMaster`/`GetReplicationInfo` etc.) — the current tests mostly use `password=""`; `TestMonitorRedisWithPort_WithPassword` only checks the `SENTINEL SET auth-pass` call succeeds, not actual authenticated replication.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_