### PR TITLE
test: add coverage for api/redisfailover/v1 register.go

### DIFF
--- a/api/redisfailover/v1/register_test.go
+++ b/api/redisfailover/v1/register_test.go
@@ -1,0 +1,42 @@
+package v1_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1 "github.com/saremox/redis-operator/api/redisfailover/v1"
+)
+
+func TestKind(t *testing.T) {
+	assertTest := assert.New(t)
+
+	gk := v1.Kind("RedisFailover")
+	assertTest.Equal(v1.SchemeGroupVersion.Group, gk.Group)
+	assertTest.Equal("RedisFailover", gk.Kind)
+}
+
+func TestVersionKind(t *testing.T) {
+	assertTest := assert.New(t)
+
+	gvk := v1.VersionKind("RedisFailover")
+	assertTest.Equal(v1.SchemeGroupVersion.WithKind("RedisFailover"), gvk)
+}
+
+func TestResource(t *testing.T) {
+	assertTest := assert.New(t)
+
+	gr := v1.Resource("redisfailovers")
+	assertTest.Equal(v1.SchemeGroupVersion.Group, gr.Group)
+	assertTest.Equal("redisfailovers", gr.Resource)
+}
+
+func TestAddToScheme(t *testing.T) {
+	assertTest := assert.New(t)
+
+	scheme := runtime.NewScheme()
+	err := v1.AddToScheme(scheme)
+	assertTest.NoError(err)
+	assertTest.True(scheme.Recognizes(v1.SchemeGroupVersion.WithKind(v1.RFKind)))
+}


### PR DESCRIPTION
## Summary
- `Kind`, `VersionKind`, `Resource`, and `addKnownTypes` (exercised via `AddToScheme`) in `api/redisfailover/v1/register.go` had 0% test coverage.
- Adds `register_test.go` covering all four.

## Test plan
- [x] `go test ./api/redisfailover/v1/...` passes
- [x] `go vet ./api/...` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_