### PR TITLE
test: cover configmap/deployment/pod/pdb delete+list+update-error paths in service/k8s

### DIFF
--- a/service/k8s/configmap_test.go
+++ b/service/k8s/configmap_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -32,6 +33,14 @@ func newConfigMapGetAction(ns, name string) kubetesting.GetActionImpl {
 
 func newConfigMapCreateAction(ns string, configMap *corev1.ConfigMap) kubetesting.CreateActionImpl {
 	return kubetesting.NewCreateAction(configMapsGroup, ns, configMap)
+}
+
+func newConfigMapDeleteAction(ns, name string) kubetesting.DeleteActionImpl {
+	return kubetesting.NewDeleteAction(configMapsGroup, ns, name)
+}
+
+func newConfigMapListAction(ns string) kubetesting.ListActionImpl {
+	return kubetesting.NewListAction(configMapsGroup, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ConfigMap"}, ns, metav1.ListOptions{})
 }
 
 func TestConfigMapServiceGetCreateOrUpdate(t *testing.T) {
@@ -116,4 +125,131 @@ func TestConfigMapServiceGetCreateOrUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConfigMapServiceUpdate(t *testing.T) {
+	testConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testconfigmap1",
+		},
+	}
+
+	testns := "testns"
+
+	tests := []struct {
+		name          string
+		errorOnUpdate error
+		expActions    []kubetesting.Action
+		expErr        bool
+	}{
+		{
+			name:          "Updating an existent configmap should not error.",
+			errorOnUpdate: nil,
+			expActions: []kubetesting.Action{
+				newConfigMapUpdateAction(testns, testConfigMap),
+			},
+			expErr: false,
+		},
+		{
+			name:          "Updating should error when the client fails.",
+			errorOnUpdate: errors.New("wanted error"),
+			expActions: []kubetesting.Action{
+				newConfigMapUpdateAction(testns, testConfigMap),
+			},
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertTest := assert.New(t)
+
+			mcli := &kubernetes.Clientset{}
+			mcli.AddReactor("update", "configmaps", func(action kubetesting.Action) (bool, runtime.Object, error) {
+				return true, nil, test.errorOnUpdate
+			})
+
+			service := k8s.NewConfigMapService(mcli, log.Dummy, metrics.Dummy)
+			err := service.UpdateConfigMap(testns, testConfigMap)
+
+			if test.expErr {
+				assertTest.Error(err)
+			} else {
+				assertTest.NoError(err)
+			}
+			assertTest.Equal(test.expActions, mcli.Actions())
+		})
+	}
+}
+
+func TestConfigMapServiceDelete(t *testing.T) {
+	testns := "testns"
+
+	t.Run("deletes an existing configmap", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		configMap := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testconfigmap1",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset(configMap)
+		service := k8s.NewConfigMapService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteConfigMap(testns, "testconfigmap1")
+		assertTest.NoError(err)
+		assertTest.Equal([]kubetesting.Action{newConfigMapDeleteAction(testns, "testconfigmap1")}, mcli.Actions())
+
+		_, getErr := mcli.CoreV1().ConfigMaps(testns).Get(context.TODO(), "testconfigmap1", metav1.GetOptions{})
+		assertTest.Error(getErr)
+		assertTest.True(kubeerrors.IsNotFound(getErr))
+	})
+
+	t.Run("returns a not found error when the configmap does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewConfigMapService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteConfigMap(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+}
+
+func TestConfigMapServiceList(t *testing.T) {
+	testns := "testns"
+
+	t.Run("lists configmaps in a namespace", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		cm1 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm1", Namespace: testns}}
+		cm2 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm2", Namespace: testns}}
+		cm3 := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cm3", Namespace: "otherns"}}
+		mcli := kubernetes.NewClientset(cm1, cm2, cm3)
+		service := k8s.NewConfigMapService(mcli, log.Dummy, metrics.Dummy)
+
+		list, err := service.ListConfigMaps(testns)
+		assertTest.NoError(err)
+		assertTest.Len(list.Items, 2)
+		names := []string{list.Items[0].Name, list.Items[1].Name}
+		assertTest.ElementsMatch([]string{"cm1", "cm2"}, names)
+	})
+
+	t.Run("returns an error when the client fails", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := &kubernetes.Clientset{}
+		wantErr := errors.New("wanted error")
+		mcli.AddReactor("list", "configmaps", func(action kubetesting.Action) (bool, runtime.Object, error) {
+			return true, nil, wantErr
+		})
+		service := k8s.NewConfigMapService(mcli, log.Dummy, metrics.Dummy)
+
+		list, err := service.ListConfigMaps(testns)
+		assertTest.Error(err)
+		assertTest.Empty(list.Items)
+		assertTest.Equal([]kubetesting.Action{newConfigMapListAction(testns)}, mcli.Actions())
+	})
 }

--- a/service/k8s/deployment_test.go
+++ b/service/k8s/deployment_test.go
@@ -1,11 +1,13 @@
 package k8s_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,6 +34,15 @@ func newDeploymentGetAction(ns, name string) kubetesting.GetActionImpl {
 
 func newDeploymentCreateAction(ns string, deployment *appsv1.Deployment) kubetesting.CreateActionImpl {
 	return kubetesting.NewCreateAction(deploymentsGroup, ns, deployment)
+}
+
+func newDeploymentDeleteAction(ns, name string) kubetesting.DeleteActionImpl {
+	propagation := metav1.DeletePropagationForeground
+	return kubetesting.NewDeleteActionWithOptions(deploymentsGroup, ns, name, metav1.DeleteOptions{PropagationPolicy: &propagation})
+}
+
+func newDeploymentListAction(ns string) kubetesting.ListActionImpl {
+	return kubetesting.NewListAction(deploymentsGroup, schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, ns, metav1.ListOptions{})
 }
 
 func TestDeploymentServiceGetCreateOrUpdate(t *testing.T) {
@@ -116,4 +127,181 @@ func TestDeploymentServiceGetCreateOrUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeploymentServiceUpdate(t *testing.T) {
+	testDeployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testdeployment1",
+		},
+	}
+
+	testns := "testns"
+
+	tests := []struct {
+		name          string
+		errorOnUpdate error
+		expActions    []kubetesting.Action
+		expErr        bool
+	}{
+		{
+			name:          "Updating an existent deployment should not error.",
+			errorOnUpdate: nil,
+			expActions: []kubetesting.Action{
+				newDeploymentUpdateAction(testns, testDeployment),
+			},
+			expErr: false,
+		},
+		{
+			name:          "Updating should error when the client fails.",
+			errorOnUpdate: errors.New("wanted error"),
+			expActions: []kubetesting.Action{
+				newDeploymentUpdateAction(testns, testDeployment),
+			},
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertTest := assert.New(t)
+
+			mcli := &kubernetes.Clientset{}
+			mcli.AddReactor("update", "deployments", func(action kubetesting.Action) (bool, runtime.Object, error) {
+				return true, nil, test.errorOnUpdate
+			})
+
+			service := k8s.NewDeploymentService(mcli, log.Dummy, metrics.Dummy)
+			err := service.UpdateDeployment(testns, testDeployment)
+
+			if test.expErr {
+				assertTest.Error(err)
+			} else {
+				assertTest.NoError(err)
+			}
+			assertTest.Equal(test.expActions, mcli.Actions())
+		})
+	}
+}
+
+func TestDeploymentServiceDelete(t *testing.T) {
+	testns := "testns"
+
+	t.Run("deletes an existing deployment", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testdeployment1",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset(deployment)
+		service := k8s.NewDeploymentService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteDeployment(testns, "testdeployment1")
+		assertTest.NoError(err)
+		assertTest.Equal([]kubetesting.Action{newDeploymentDeleteAction(testns, "testdeployment1")}, mcli.Actions())
+
+		_, getErr := mcli.AppsV1().Deployments(testns).Get(context.TODO(), "testdeployment1", metav1.GetOptions{})
+		assertTest.Error(getErr)
+		assertTest.True(kubeerrors.IsNotFound(getErr))
+	})
+
+	t.Run("returns a not found error when the deployment does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewDeploymentService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteDeployment(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+}
+
+func TestDeploymentServiceList(t *testing.T) {
+	testns := "testns"
+
+	t.Run("lists deployments in a namespace", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		d1 := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "d1", Namespace: testns}}
+		d2 := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "d2", Namespace: testns}}
+		d3 := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "d3", Namespace: "otherns"}}
+		mcli := kubernetes.NewClientset(d1, d2, d3)
+		service := k8s.NewDeploymentService(mcli, log.Dummy, metrics.Dummy)
+
+		list, err := service.ListDeployments(testns)
+		assertTest.NoError(err)
+		assertTest.Len(list.Items, 2)
+		names := []string{list.Items[0].Name, list.Items[1].Name}
+		assertTest.ElementsMatch([]string{"d1", "d2"}, names)
+	})
+
+	t.Run("returns an error when the client fails", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := &kubernetes.Clientset{}
+		wantErr := errors.New("wanted error")
+		mcli.AddReactor("list", "deployments", func(action kubetesting.Action) (bool, runtime.Object, error) {
+			return true, nil, wantErr
+		})
+		service := k8s.NewDeploymentService(mcli, log.Dummy, metrics.Dummy)
+
+		list, err := service.ListDeployments(testns)
+		assertTest.Error(err)
+		assertTest.Empty(list.Items)
+		assertTest.Equal([]kubetesting.Action{newDeploymentListAction(testns)}, mcli.Actions())
+	})
+}
+
+func TestDeploymentServiceGetDeploymentPods(t *testing.T) {
+	testns := "testns"
+
+	t.Run("returns pods matching the deployment's selector", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: "testdeployment1", Namespace: testns},
+			Spec: appsv1.DeploymentSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "redis"},
+				},
+			},
+		}
+		matchingPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "matchingpod",
+				Namespace: testns,
+				Labels:    map[string]string{"app": "redis"},
+			},
+		}
+		otherPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "otherpod",
+				Namespace: testns,
+				Labels:    map[string]string{"app": "other"},
+			},
+		}
+		mcli := kubernetes.NewClientset(deployment, matchingPod, otherPod)
+		service := k8s.NewDeploymentService(mcli, log.Dummy, metrics.Dummy)
+
+		pods, err := service.GetDeploymentPods(testns, "testdeployment1")
+		assertTest.NoError(err)
+		assertTest.Len(pods.Items, 1)
+		assertTest.Equal("matchingpod", pods.Items[0].Name)
+	})
+
+	t.Run("returns an error when the deployment does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewDeploymentService(mcli, log.Dummy, metrics.Dummy)
+
+		pods, err := service.GetDeploymentPods(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+		assertTest.Nil(pods)
+	})
 }

--- a/service/k8s/pod_test.go
+++ b/service/k8s/pod_test.go
@@ -35,6 +35,14 @@ func newPodCreateAction(ns string, pod *corev1.Pod) kubetesting.CreateActionImpl
 	return kubetesting.NewCreateAction(podsGroup, ns, pod)
 }
 
+func newPodDeleteAction(ns, name string) kubetesting.DeleteActionImpl {
+	return kubetesting.NewDeleteAction(podsGroup, ns, name)
+}
+
+func newPodListAction(ns string) kubetesting.ListActionImpl {
+	return kubetesting.NewListAction(podsGroup, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"}, ns, metav1.ListOptions{})
+}
+
 // TestPodServiceUpdatePodLabels exercises UpdatePodLabels, the mechanism
 // behind master/slave role-label updates during failover. It builds a JSON
 // Patch with Op "replace", which per RFC 6902 requires the target path to
@@ -246,4 +254,131 @@ func TestPodServiceGetCreateOrUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPodServiceUpdate(t *testing.T) {
+	testPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testpod1",
+		},
+	}
+
+	testns := "testns"
+
+	tests := []struct {
+		name          string
+		errorOnUpdate error
+		expActions    []kubetesting.Action
+		expErr        bool
+	}{
+		{
+			name:          "Updating an existent pod should not error.",
+			errorOnUpdate: nil,
+			expActions: []kubetesting.Action{
+				newPodUpdateAction(testns, testPod),
+			},
+			expErr: false,
+		},
+		{
+			name:          "Updating should error when the client fails.",
+			errorOnUpdate: errors.New("wanted error"),
+			expActions: []kubetesting.Action{
+				newPodUpdateAction(testns, testPod),
+			},
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertTest := assert.New(t)
+
+			mcli := &kubernetes.Clientset{}
+			mcli.AddReactor("update", "pods", func(action kubetesting.Action) (bool, runtime.Object, error) {
+				return true, nil, test.errorOnUpdate
+			})
+
+			service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+			err := service.UpdatePod(testns, testPod)
+
+			if test.expErr {
+				assertTest.Error(err)
+			} else {
+				assertTest.NoError(err)
+			}
+			assertTest.Equal(test.expActions, mcli.Actions())
+		})
+	}
+}
+
+func TestPodServiceDelete(t *testing.T) {
+	testns := "testns"
+
+	t.Run("deletes an existing pod", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testpod1",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset(pod)
+		service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeletePod(testns, "testpod1")
+		assertTest.NoError(err)
+		assertTest.Equal([]kubetesting.Action{newPodDeleteAction(testns, "testpod1")}, mcli.Actions())
+
+		_, getErr := mcli.CoreV1().Pods(testns).Get(context.TODO(), "testpod1", metav1.GetOptions{})
+		assertTest.Error(getErr)
+		assertTest.True(kubeerrors.IsNotFound(getErr))
+	})
+
+	t.Run("returns a not found error when the pod does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeletePod(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+}
+
+func TestPodServiceList(t *testing.T) {
+	testns := "testns"
+
+	t.Run("lists pods in a namespace", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		p1 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Namespace: testns}}
+		p2 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: testns}}
+		p3 := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p3", Namespace: "otherns"}}
+		mcli := kubernetes.NewClientset(p1, p2, p3)
+		service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+
+		list, err := service.ListPods(testns)
+		assertTest.NoError(err)
+		assertTest.Len(list.Items, 2)
+		names := []string{list.Items[0].Name, list.Items[1].Name}
+		assertTest.ElementsMatch([]string{"p1", "p2"}, names)
+	})
+
+	t.Run("returns an error when the client fails", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := &kubernetes.Clientset{}
+		wantErr := errors.New("wanted error")
+		mcli.AddReactor("list", "pods", func(action kubetesting.Action) (bool, runtime.Object, error) {
+			return true, nil, wantErr
+		})
+		service := k8s.NewPodService(mcli, log.Dummy, metrics.Dummy)
+
+		list, err := service.ListPods(testns)
+		assertTest.Error(err)
+		assertTest.Empty(list.Items)
+		assertTest.Equal([]kubetesting.Action{newPodListAction(testns)}, mcli.Actions())
+	})
 }

--- a/service/k8s/poddisruptionbudget_test.go
+++ b/service/k8s/poddisruptionbudget_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -30,6 +31,10 @@ func newPodDisruptionBudgetGetAction(ns, name string) kubetesting.GetActionImpl 
 
 func newPodDisruptionBudgetCreateAction(ns string, podDisruptionBudget *policyv1.PodDisruptionBudget) kubetesting.CreateActionImpl {
 	return kubetesting.NewCreateAction(podDisruptionBudgetsGroup, ns, podDisruptionBudget)
+}
+
+func newPodDisruptionBudgetDeleteAction(ns, name string) kubetesting.DeleteActionImpl {
+	return kubetesting.NewDeleteAction(podDisruptionBudgetsGroup, ns, name)
 }
 
 func TestPodDisruptionBudgetServiceGetCreateOrUpdate(t *testing.T) {
@@ -114,4 +119,95 @@ func TestPodDisruptionBudgetServiceGetCreateOrUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPodDisruptionBudgetServiceUpdate(t *testing.T) {
+	testPodDisruptionBudget := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testpodDisruptionBudget1",
+		},
+	}
+
+	testns := "testns"
+
+	tests := []struct {
+		name          string
+		errorOnUpdate error
+		expActions    []kubetesting.Action
+		expErr        bool
+	}{
+		{
+			name:          "Updating an existent podDisruptionBudget should not error.",
+			errorOnUpdate: nil,
+			expActions: []kubetesting.Action{
+				newPodDisruptionBudgetUpdateAction(testns, testPodDisruptionBudget),
+			},
+			expErr: false,
+		},
+		{
+			name:          "Updating should error when the client fails.",
+			errorOnUpdate: errors.New("wanted error"),
+			expActions: []kubetesting.Action{
+				newPodDisruptionBudgetUpdateAction(testns, testPodDisruptionBudget),
+			},
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertTest := assert.New(t)
+
+			mcli := &kubernetes.Clientset{}
+			mcli.AddReactor("update", "poddisruptionbudgets", func(action kubetesting.Action) (bool, runtime.Object, error) {
+				return true, nil, test.errorOnUpdate
+			})
+
+			service := k8s.NewPodDisruptionBudgetService(mcli, log.Dummy, metrics.Dummy)
+			err := service.UpdatePodDisruptionBudget(testns, testPodDisruptionBudget)
+
+			if test.expErr {
+				assertTest.Error(err)
+			} else {
+				assertTest.NoError(err)
+			}
+			assertTest.Equal(test.expActions, mcli.Actions())
+		})
+	}
+}
+
+func TestPodDisruptionBudgetServiceDelete(t *testing.T) {
+	testns := "testns"
+
+	t.Run("deletes an existing podDisruptionBudget", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		pdb := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testpodDisruptionBudget1",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset(pdb)
+		service := k8s.NewPodDisruptionBudgetService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeletePodDisruptionBudget(testns, "testpodDisruptionBudget1")
+		assertTest.NoError(err)
+		assertTest.Equal([]kubetesting.Action{newPodDisruptionBudgetDeleteAction(testns, "testpodDisruptionBudget1")}, mcli.Actions())
+
+		_, getErr := mcli.PolicyV1().PodDisruptionBudgets(testns).Get(context.TODO(), "testpodDisruptionBudget1", metav1.GetOptions{})
+		assertTest.Error(getErr)
+		assertTest.True(kubeerrors.IsNotFound(getErr))
+	})
+
+	t.Run("returns a not found error when the podDisruptionBudget does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewPodDisruptionBudgetService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeletePodDisruptionBudget(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
 }


### PR DESCRIPTION
## Summary

Raises unit test coverage in `service/k8s/` for four files that already had test files but were missing cases for several 0%-covered and partially-covered functions:

- `configmap.go` / `configmap_test.go`: `DeleteConfigMap` (0% -> 100%), `ListConfigMaps` (0% -> 100%), `UpdateConfigMap` (83.3% -> 100%, added the update-error branch)
- `deployment.go` / `deployment_test.go`: `DeleteDeployment` (0% -> 100%), `ListDeployments` (0% -> 100%), `GetDeploymentPods` (0% -> 100%), `UpdateDeployment` (83.3% -> 100%, added the update-error branch)
- `pod.go` / `pod_test.go`: `DeletePod` (0% -> 100%), `ListPods` (0% -> 100%), `UpdatePod` (83.3% -> 100%, added the update-error branch)
- `poddisruptionbudget.go` / `poddisruptionbudget_test.go`: `DeletePodDisruptionBudget` (0% -> 100%), `UpdatePodDisruptionBudget` (83.3% -> 100%, added the update-error branch)

All new tests follow the existing table-driven / `kubetesting.Action`-assertion style already used in each file, and use `kubernetes.NewClientset()` (not the deprecated `NewSimpleClientset`) where a populated fake clientset is needed for Delete/List cases.

`service/k8s` package coverage moved from 72.0% to 80.5%. Only the four `_test.go` files listed above were touched — no production code changes.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./service/k8s/...`
- [x] `go test ./...` (full repo suite)
- [x] `golangci-lint run --no-config ./service/k8s/...` (0 issues)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_