### PR TITLE
test: cover label-sync and revision-lookup branches in check.go/heal.go

### DIFF
--- a/operator/redisfailover/service/check_test.go
+++ b/operator/redisfailover/service/check_test.go
@@ -252,6 +252,68 @@ func TestCheckAllSlavesFromMaster(t *testing.T) {
 	assert.NoError(err)
 }
 
+func TestCheckAllSlavesFromMasterMasterAlreadyLabeled(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"redisfailovers-role": "master"},
+				},
+				Status: corev1.PodStatus{
+					PodIP: "0.0.0.0",
+					Phase: corev1.PodRunning,
+				},
+			},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	mr := &mRedisService.Client{}
+	mr.On("GetSlaveOf", "0.0.0.0", "0", "").Once().Return("", nil)
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	err := checker.CheckAllSlavesFromMaster("0.0.0.0", rf)
+	assert.NoError(err)
+	ms.AssertExpectations(t) // pod already has the master label, so UpdatePodLabels must not be called
+}
+
+func TestCheckAllSlavesFromMasterSlaveAlreadyLabeled(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"redisfailovers-role": "slave"},
+				},
+				Status: corev1.PodStatus{
+					PodIP: "1.1.1.1",
+					Phase: corev1.PodRunning,
+				},
+			},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	mr := &mRedisService.Client{}
+	mr.On("GetSlaveOf", "1.1.1.1", "0", "").Once().Return("0.0.0.0", nil)
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	err := checker.CheckAllSlavesFromMaster("0.0.0.0", rf)
+	assert.NoError(err)
+	ms.AssertExpectations(t) // pod already has the slave label, so UpdatePodLabels must not be called
+}
+
 func TestCheckSentinelNumberInMemoryGetDeploymentPodsError(t *testing.T) {
 	assert := assert.New(t)
 
@@ -351,6 +413,40 @@ func TestCheckSentinelSlavesNumberInMemory(t *testing.T) {
 	ms := &mK8SService.Services{}
 	mr := &mRedisService.Client{}
 	mr.On("GetNumberSentinelSlavesInMemory", "1.1.1.1").Once().Return(int32(4), nil)
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	err := checker.CheckSentinelSlavesNumberInMemory("1.1.1.1", rf)
+	assert.NoError(err)
+}
+
+func TestCheckSentinelSlavesNumberInMemoryBootstrappingMismatch(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+	rf.Spec.BootstrapNode = &redisfailoverv1.BootstrapSettings{Host: "127.0.0.1"}
+	rf.Spec.Redis.Replicas = 3
+
+	ms := &mK8SService.Services{}
+	mr := &mRedisService.Client{}
+	mr.On("GetNumberSentinelSlavesInMemory", "1.1.1.1").Once().Return(int32(2), nil)
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	err := checker.CheckSentinelSlavesNumberInMemory("1.1.1.1", rf)
+	assert.Error(err, "while bootstrapping, sentinel slave count must match replicas exactly")
+}
+
+func TestCheckSentinelSlavesNumberInMemoryBootstrappingMatch(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+	rf.Spec.BootstrapNode = &redisfailoverv1.BootstrapSettings{Host: "127.0.0.1"}
+	rf.Spec.Redis.Replicas = 3
+
+	ms := &mK8SService.Services{}
+	mr := &mRedisService.Client{}
+	mr.On("GetNumberSentinelSlavesInMemory", "1.1.1.1").Once().Return(int32(3), nil)
 
 	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
 
@@ -775,6 +871,162 @@ func TestGetRedisPodsNames(t *testing.T) {
 	assert.Equal(namePods, []string{"slave1", "slave2"})
 }
 
+// --- GetRedisesMasterPod ---
+
+func TestGetRedisesMasterPodGetStatefulSetPodsError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(nil, errors.New("boom"))
+	mr := &mRedisService.Client{}
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	master, err := checker.GetRedisesMasterPod(rf)
+	assert.Error(err)
+	assert.Equal("", master)
+}
+
+func TestGetRedisesMasterPodPasswordError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+	rf.Spec.Auth.SecretPath = "redis-secret"
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{Status: corev1.PodStatus{PodIP: "0.0.0.0", Phase: corev1.PodRunning}},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	ms.On("GetSecret", namespace, "redis-secret").Once().Return(nil, errors.New("secret unavailable"))
+	mr := &mRedisService.Client{}
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	master, err := checker.GetRedisesMasterPod(rf)
+	assert.Error(err)
+	assert.Equal("", master)
+	mr.AssertExpectations(t) // no IsMaster call should have happened
+}
+
+func TestGetRedisesMasterPodIsMasterError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{Status: corev1.PodStatus{PodIP: "0.0.0.0", Phase: corev1.PodRunning}},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	mr := &mRedisService.Client{}
+	mr.On("IsMaster", "0.0.0.0", "0", "").Once().Return(false, errors.New("timeout"))
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	master, err := checker.GetRedisesMasterPod(rf)
+	assert.Error(err)
+	assert.Equal("", master)
+}
+
+func TestGetRedisesMasterPodNotFound(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{Status: corev1.PodStatus{PodIP: "0.0.0.0", Phase: corev1.PodRunning}},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	mr := &mRedisService.Client{}
+	mr.On("IsMaster", "0.0.0.0", "0", "").Once().Return(false, nil)
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	master, err := checker.GetRedisesMasterPod(rf)
+	assert.Error(err)
+	assert.Contains(err.Error(), "not found")
+	assert.Equal("", master)
+}
+
+// --- GetRedisesSlavesPods ---
+
+func TestGetRedisesSlavesPodsGetStatefulSetPodsError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(nil, errors.New("boom"))
+	mr := &mRedisService.Client{}
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	slaves, err := checker.GetRedisesSlavesPods(rf)
+	assert.Error(err)
+	assert.Nil(slaves)
+}
+
+func TestGetRedisesSlavesPodsPasswordError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+	rf.Spec.Auth.SecretPath = "redis-secret"
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{Status: corev1.PodStatus{PodIP: "0.0.0.0", Phase: corev1.PodRunning}},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	ms.On("GetSecret", namespace, "redis-secret").Once().Return(nil, errors.New("secret unavailable"))
+	mr := &mRedisService.Client{}
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	slaves, err := checker.GetRedisesSlavesPods(rf)
+	assert.Error(err)
+	assert.Empty(slaves)
+	mr.AssertExpectations(t) // no IsMaster call should have happened
+}
+
+func TestGetRedisesSlavesPodsIsMasterError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{Status: corev1.PodStatus{PodIP: "0.0.0.0", Phase: corev1.PodRunning}},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	mr := &mRedisService.Client{}
+	mr.On("IsMaster", "0.0.0.0", "0", "").Once().Return(false, errors.New("timeout"))
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	slaves, err := checker.GetRedisesSlavesPods(rf)
+	assert.Error(err)
+	assert.Empty(slaves)
+}
+
 func TestGetStatefulSetUpdateRevision(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -822,6 +1074,21 @@ func TestGetStatefulSetUpdateRevision(t *testing.T) {
 
 }
 
+func TestGetStatefulSetUpdateRevisionGetStatefulSetError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSet", namespace, rfservice.GetRedisName(rf)).Once().Return(nil, errors.New("boom"))
+	mr := &mRedisService.Client{}
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+	version, err := checker.GetStatefulSetUpdateRevision(rf)
+
+	assert.Error(err)
+	assert.Equal("", version)
+}
+
 func TestGetRedisRevisionHash(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -847,6 +1114,14 @@ func TestGetRedisRevisionHash(t *testing.T) {
 			expectedHash:  "",
 			expectedError: errors.New("not found"),
 		},
+		{
+			name: "pod has no labels",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{},
+			},
+			expectedHash:  "",
+			expectedError: errors.New("labels not found"),
+		},
 	}
 
 	for _, test := range tests {
@@ -869,6 +1144,21 @@ func TestGetRedisRevisionHash(t *testing.T) {
 		assert.Equal(hash, test.expectedHash)
 	}
 
+}
+
+func TestGetRedisRevisionHashGetPodError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+	ms := &mK8SService.Services{}
+	ms.On("GetPod", namespace, "namepod").Once().Return(nil, errors.New("boom"))
+	mr := &mRedisService.Client{}
+
+	checker := rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+	hash, err := checker.GetRedisRevisionHash("namepod", rf)
+
+	assert.Error(err)
+	assert.Equal("", hash)
 }
 
 func TestClusterRunning(t *testing.T) {

--- a/operator/redisfailover/service/heal_test.go
+++ b/operator/redisfailover/service/heal_test.go
@@ -305,6 +305,42 @@ func TestSetMasterOnAllRejectsIPNotOwnedByRF(t *testing.T) {
 	mr.AssertExpectations(t) // no IsMaster/MakeSlaveOfWithPort calls should have happened
 }
 
+func TestSetMasterOnAllSlaveAlreadyLabeled(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+
+	pods := &corev1.PodList{
+		Items: []corev1.Pod{
+			{
+				Status: corev1.PodStatus{
+					PodIP: "0.0.0.0",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"redisfailovers-role": "slave"},
+				},
+				Status: corev1.PodStatus{
+					PodIP: "1.1.1.1",
+				},
+			},
+		},
+	}
+
+	ms := &mK8SService.Services{}
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
+	mr := &mRedisService.Client{}
+	mr.On("IsMaster", "0.0.0.0", "0", "").Return(true, nil)
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(nil)
+
+	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
+
+	err := healer.SetMasterOnAll("0.0.0.0", rf)
+	assert.NoError(err)
+	ms.AssertExpectations(t) // pod already has the slave label, so UpdatePodLabels must not be called
+}
+
 func TestSetExternalMasterOnAll(t *testing.T) {
 	tests := []struct {
 		name                  string
@@ -616,6 +652,40 @@ func TestNewSentinelMonitor(t *testing.T) {
 			mr.AssertExpectations(t)
 		})
 	}
+}
+
+func TestNewSentinelMonitorPasswordError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+	rf.Spec.Auth.SecretPath = "redis-secret"
+
+	ms := &mK8SService.Services{}
+	ms.On("GetSecret", namespace, "redis-secret").Once().Return(nil, errors.New("secret unavailable"))
+	mr := &mRedisService.Client{}
+
+	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
+
+	err := healer.NewSentinelMonitor("0.0.0.0", "1.1.1.1", rf)
+	assert.Error(err)
+	mr.AssertExpectations(t) // no MonitorRedisWithPort call should have happened
+}
+
+func TestNewSentinelMonitorWithPortPasswordError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF()
+	rf.Spec.Auth.SecretPath = "redis-secret"
+
+	ms := &mK8SService.Services{}
+	ms.On("GetSecret", namespace, "redis-secret").Once().Return(nil, errors.New("secret unavailable"))
+	mr := &mRedisService.Client{}
+
+	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
+
+	err := healer.NewSentinelMonitorWithPort("0.0.0.0", "1.1.1.1", "6379", rf)
+	assert.Error(err)
+	mr.AssertExpectations(t) // no MonitorRedisWithPort call should have happened
 }
 
 // --- MakeMaster ---


### PR DESCRIPTION
## Summary

Raises unit test coverage in `operator/redisfailover/service/check.go` and `heal.go` by adding test cases for previously-uncovered branches. Only `check_test.go` and `heal_test.go` were modified — no production code changes.

New coverage added for:
- `setMasterLabelIfNecessary` / `setSlaveLabelIfNecessary` (both `check.go` and `heal.go`): the "already has the correct label" no-op branch, exercised via `CheckAllSlavesFromMaster` and `SetMasterOnAll` respectively (previously only the "needs relabeling" branch was tested)
- `GetRedisesMasterPod` / `GetRedisesSlavesPods`: `GetStatefulSetPods` error, password-fetch error, `IsMaster` error, and (for `GetRedisesMasterPod`) the "no master found" case
- `CheckSentinelSlavesNumberInMemory`: the `rf.Bootstrapping() == true` branch (mismatch and match cases)
- `GetRedisRevisionHash`: `GetPod` error and pod-with-nil-labels cases
- `GetStatefulSetUpdateRevision`: `GetStatefulSet` error case
- `NewSentinelMonitor` / `NewSentinelMonitorWithPort`: password-fetch error case

### Coverage before/after (package `operator/redisfailover/service`)

Package total: 90.0% → 92.4%

All target functions now report 100%:
- `check.go`: `setSlaveLabelIfNecessary` 50%→100%, `setMasterLabelIfNecessary` 50%→100%, `GetRedisesMasterPod` 73.3%→100%, `CheckSentinelSlavesNumberInMemory` 77.8%→100%, `GetRedisRevisionHash` 77.8%→100%, `GetRedisesSlavesPods` 81.2%→100%, `GetStatefulSetUpdateRevision` 83.3%→100%
- `heal.go`: `setSlaveLabelIfNecessary` 50%→100%, `NewSentinelMonitorWithPort` 80%→100%, `NewSentinelMonitor` 83.3%→100%

## Local validation checklist

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./operator/redisfailover/...`
- [x] `go test ./...` (full repo)
- [x] `golangci-lint run --no-config ./operator/redisfailover/...` — 0 issues

Note: this is one of several parallel coverage-improvement PRs touching non-overlapping files in this package; only `check_test.go` and `heal_test.go` were touched here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_