### PR TITLE
test: cover rbac/service/statefulset gaps and add redisfailover.go tests in service/k8s

### DIFF
--- a/service/k8s/rbac_test.go
+++ b/service/k8s/rbac_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -19,7 +20,8 @@ import (
 )
 
 var (
-	rbGroup = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
+	rbGroup   = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "rolebindings"}
+	roleGroup = schema.GroupVersionResource{Group: "rbac.authorization.k8s.io", Version: "v1", Resource: "roles"}
 )
 
 func newRBUpdateAction(ns string, rb *rbacv1.RoleBinding) kubetesting.UpdateActionImpl {
@@ -35,6 +37,18 @@ func newRBCreateAction(ns string, rb *rbacv1.RoleBinding) kubetesting.CreateActi
 }
 func newRBDeleteAction(ns string, name string) kubetesting.DeleteActionImpl {
 	return kubetesting.NewDeleteAction(rbGroup, ns, name)
+}
+
+func newRoleGetAction(ns, name string) kubetesting.GetActionImpl {
+	return kubetesting.NewGetAction(roleGroup, ns, name)
+}
+
+func newRoleCreateAction(ns string, role *rbacv1.Role) kubetesting.CreateActionImpl {
+	return kubetesting.NewCreateAction(roleGroup, ns, role)
+}
+
+func newRoleUpdateAction(ns string, role *rbacv1.Role) kubetesting.UpdateActionImpl {
+	return kubetesting.NewUpdateAction(roleGroup, ns, role)
 }
 
 func TestRBACServiceGetCreateOrUpdateRoleBinding(t *testing.T) {
@@ -143,4 +157,344 @@ func TestRBACServiceGetCreateOrUpdateRoleBinding(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRBACServiceGetClusterRole(t *testing.T) {
+	t.Run("returns an existing ClusterRole", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		cr := &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testclusterrole",
+			},
+		}
+		mcli := kubernetes.NewClientset(cr)
+		service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+		got, err := service.GetClusterRole("testclusterrole")
+		assertTest.NoError(err)
+		assertTest.NotNil(got)
+		assertTest.Equal("testclusterrole", got.Name)
+	})
+
+	t.Run("returns an error when the ClusterRole does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+		_, err := service.GetClusterRole("does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+}
+
+func TestRBACServiceGetRole(t *testing.T) {
+	testns := "testns"
+
+	t.Run("returns an existing Role", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		role := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testrole",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset(role)
+		service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+		got, err := service.GetRole(testns, "testrole")
+		assertTest.NoError(err)
+		assertTest.NotNil(got)
+		assertTest.Equal("testrole", got.Name)
+	})
+
+	t.Run("returns an error when the Role does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+		_, err := service.GetRole(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+}
+
+func TestRBACServiceDeleteRole(t *testing.T) {
+	testns := "testns"
+
+	t.Run("deletes an existing Role", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		role := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testrole",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset(role)
+		service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteRole(testns, "testrole")
+		assertTest.NoError(err)
+
+		_, err = mcli.RbacV1().Roles(testns).Get(context.TODO(), "testrole", metav1.GetOptions{})
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+
+	t.Run("returns an error when deleting a non-existent Role", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteRole(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+}
+
+func TestRBACServiceCreateRole(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testrole",
+			Namespace: testns,
+		},
+	}
+	mcli := kubernetes.NewClientset()
+	service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+	err := service.CreateRole(testns, role)
+	assertTest.NoError(err)
+
+	got, err := mcli.RbacV1().Roles(testns).Get(context.TODO(), "testrole", metav1.GetOptions{})
+	assertTest.NoError(err)
+	assertTest.Equal("testrole", got.Name)
+}
+
+func TestRBACServiceUpdateRole(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testrole",
+			Namespace: testns,
+			Labels:    map[string]string{"foo": "bar"},
+		},
+	}
+	mcli := kubernetes.NewClientset(role)
+	service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+	role.Labels["foo"] = "baz"
+	err := service.UpdateRole(testns, role)
+	assertTest.NoError(err)
+
+	got, err := mcli.RbacV1().Roles(testns).Get(context.TODO(), "testrole", metav1.GetOptions{})
+	assertTest.NoError(err)
+	assertTest.Equal("baz", got.Labels["foo"])
+}
+
+func TestRBACServiceUpdateRoleError(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "does-not-exist",
+		},
+	}
+	mcli := kubernetes.NewClientset()
+	service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+	err := service.UpdateRole(testns, role)
+	assertTest.Error(err)
+	assertTest.True(kubeerrors.IsNotFound(err))
+}
+
+func TestRBACServiceGetCreateOrUpdateRole(t *testing.T) {
+	testRole := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test1",
+			ResourceVersion: "15",
+		},
+	}
+
+	testns := "testns"
+
+	tests := []struct {
+		name            string
+		role            *rbacv1.Role
+		getRoleResult   *rbacv1.Role
+		errorOnGet      error
+		errorOnCreation error
+		expActions      []kubetesting.Action
+		expErr          bool
+	}{
+		{
+			name:            "A new role should create a new role.",
+			role:            testRole,
+			getRoleResult:   nil,
+			errorOnGet:      kubeerrors.NewNotFound(schema.GroupResource{}, ""),
+			errorOnCreation: nil,
+			expActions: []kubetesting.Action{
+				newRoleGetAction(testns, testRole.Name),
+				newRoleCreateAction(testns, testRole),
+			},
+			expErr: false,
+		},
+		{
+			name:            "A new role should error when create a new role fails.",
+			role:            testRole,
+			getRoleResult:   nil,
+			errorOnGet:      kubeerrors.NewNotFound(schema.GroupResource{}, ""),
+			errorOnCreation: errors.New("wanted error"),
+			expActions: []kubetesting.Action{
+				newRoleGetAction(testns, testRole.Name),
+				newRoleCreateAction(testns, testRole),
+			},
+			expErr: true,
+		},
+		{
+			name:            "An existent role should update the role.",
+			role:            testRole,
+			getRoleResult:   testRole,
+			errorOnGet:      nil,
+			errorOnCreation: nil,
+			expActions: []kubetesting.Action{
+				newRoleGetAction(testns, testRole.Name),
+				newRoleUpdateAction(testns, testRole),
+			},
+			expErr: false,
+		},
+		{
+			name:            "A non-NotFound error on get should be returned as-is, without creating or updating.",
+			role:            testRole,
+			getRoleResult:   nil,
+			errorOnGet:      errors.New("connection refused"),
+			errorOnCreation: nil,
+			expActions: []kubetesting.Action{
+				newRoleGetAction(testns, testRole.Name),
+			},
+			expErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertTest := assert.New(t)
+
+			// Mock.
+			mcli := &kubernetes.Clientset{}
+			mcli.AddReactor("get", "roles", func(action kubetesting.Action) (bool, runtime.Object, error) {
+				return true, test.getRoleResult, test.errorOnGet
+			})
+			mcli.AddReactor("create", "roles", func(action kubetesting.Action) (bool, runtime.Object, error) {
+				return true, nil, test.errorOnCreation
+			})
+
+			service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+			err := service.CreateOrUpdateRole(testns, test.role)
+
+			if test.expErr {
+				assertTest.Error(err)
+			} else {
+				assertTest.NoError(err)
+				// Check calls to kubernetes.
+				assertTest.Equal(test.expActions, mcli.Actions())
+			}
+		})
+	}
+}
+
+func TestRBACServiceDeleteRoleBindingError(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	mcli := kubernetes.NewClientset()
+	service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+	err := service.DeleteRoleBinding(testns, "does-not-exist")
+	assertTest.Error(err)
+	assertTest.True(kubeerrors.IsNotFound(err))
+}
+
+func TestRBACServiceUpdateRoleBindingError(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "does-not-exist",
+		},
+	}
+	mcli := kubernetes.NewClientset()
+	service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+
+	err := service.UpdateRoleBinding(testns, binding)
+	assertTest.Error(err)
+	assertTest.True(kubeerrors.IsNotFound(err))
+}
+
+func TestRBACServiceCreateOrUpdateRoleBindingGetError(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test1",
+		},
+	}
+
+	mcli := &kubernetes.Clientset{}
+	mcli.AddReactor("get", "rolebindings", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+	err := service.CreateOrUpdateRoleBinding(testns, binding)
+	assertTest.Error(err)
+	assertTest.Equal([]kubetesting.Action{newRBGetAction(testns, binding.Name)}, mcli.Actions())
+}
+
+func TestRBACServiceCreateOrUpdateRoleBindingRoleRefChangeDeleteError(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	testRB := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test1",
+			ResourceVersion: "15",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "test1",
+		},
+	}
+	storedRB := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test1",
+			ResourceVersion: "15",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "oldroleRef",
+		},
+	}
+
+	mcli := &kubernetes.Clientset{}
+	mcli.AddReactor("get", "rolebindings", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		return true, storedRB, nil
+	})
+	mcli.AddReactor("delete", "rolebindings", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("wanted delete error")
+	})
+
+	service := k8s.NewRBACService(mcli, log.Dummy, metrics.Dummy)
+	err := service.CreateOrUpdateRoleBinding(testns, testRB)
+	assertTest.Error(err)
 }

--- a/service/k8s/redisfailover_test.go
+++ b/service/k8s/redisfailover_test.go
@@ -1,0 +1,107 @@
+package k8s_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	redisfailoverv1 "github.com/saremox/redis-operator/api/redisfailover/v1"
+	redisfailoverfake "github.com/saremox/redis-operator/client/k8s/clientset/versioned/fake"
+	"github.com/saremox/redis-operator/log"
+	"github.com/saremox/redis-operator/metrics"
+	"github.com/saremox/redis-operator/service/k8s"
+)
+
+func TestRedisFailoverServiceListRedisFailovers(t *testing.T) {
+	testns := "testns"
+
+	rf1 := &redisfailoverv1.RedisFailover{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rf1",
+			Namespace: testns,
+		},
+	}
+	rf2 := &redisfailoverv1.RedisFailover{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rf2",
+			Namespace: testns,
+		},
+	}
+	otherNsRf := &redisfailoverv1.RedisFailover{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rf3",
+			Namespace: "otherns",
+		},
+	}
+
+	crdcli := redisfailoverfake.NewSimpleClientset(rf1, rf2, otherNsRf)
+	service := k8s.NewRedisFailoverService(crdcli, log.Dummy, metrics.Dummy)
+
+	list, err := service.ListRedisFailovers(context.TODO(), testns, metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, list)
+	assert.Len(t, list.Items, 2)
+
+	gotNames := map[string]bool{}
+	for _, rf := range list.Items {
+		gotNames[rf.Name] = true
+	}
+	assert.True(t, gotNames["rf1"])
+	assert.True(t, gotNames["rf2"])
+	assert.False(t, gotNames["rf3"], "redisfailover in a different namespace must be excluded")
+}
+
+func TestRedisFailoverServiceWatchRedisFailovers(t *testing.T) {
+	testns := "testns"
+
+	crdcli := redisfailoverfake.NewSimpleClientset()
+	service := k8s.NewRedisFailoverService(crdcli, log.Dummy, metrics.Dummy)
+
+	watcher, err := service.WatchRedisFailovers(context.TODO(), testns, metav1.ListOptions{})
+	assert.NoError(t, err)
+	assert.NotNil(t, watcher)
+	watcher.Stop()
+}
+
+func TestRedisFailoverServiceUpdateRedisFailoverStatus(t *testing.T) {
+	testns := "testns"
+
+	rf := &redisfailoverv1.RedisFailover{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rf1",
+			Namespace: testns,
+		},
+		Status: redisfailoverv1.RedisFailoverStatus{
+			State:       redisfailoverv1.HealthyState,
+			LastChanged: "2026-08-23T00:00:00Z",
+			Message:     "all good",
+		},
+	}
+
+	t.Run("patches the status of an existing RedisFailover", func(t *testing.T) {
+		crdcli := redisfailoverfake.NewSimpleClientset(rf)
+		service := k8s.NewRedisFailoverService(crdcli, log.Dummy, metrics.Dummy)
+
+		// UpdateRedisFailoverStatus does not return an error, it only logs on
+		// failure, so we assert it does not panic and check the patch went
+		// through via the underlying clientset.
+		assert.NotPanics(t, func() {
+			service.UpdateRedisFailoverStatus(context.TODO(), testns, rf, metav1.PatchOptions{})
+		})
+
+		got, err := crdcli.DatabasesV1().RedisFailovers(testns).Get(context.TODO(), "rf1", metav1.GetOptions{})
+		assert.NoError(t, err)
+		assert.Equal(t, redisfailoverv1.HealthyState, got.Status.State)
+	})
+
+	t.Run("does not panic when patching a non-existent RedisFailover", func(t *testing.T) {
+		crdcli := redisfailoverfake.NewSimpleClientset()
+		service := k8s.NewRedisFailoverService(crdcli, log.Dummy, metrics.Dummy)
+
+		assert.NotPanics(t, func() {
+			service.UpdateRedisFailoverStatus(context.TODO(), testns, rf, metav1.PatchOptions{})
+		})
+	})
+}

--- a/service/k8s/service_test.go
+++ b/service/k8s/service_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -233,4 +234,136 @@ func TestCreateOrUpdateServicePreservesHealthCheckNodePort(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, int32(32100), updatedService.Spec.HealthCheckNodePort, "healthCheckNodePort must be preserved")
 	assert.Equal(t, "10.0.0.2", updatedService.Spec.ClusterIP, "clusterIP must be preserved")
+}
+
+func TestServiceServiceCreateOrUpdateServiceGetError(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "testsvc",
+		},
+	}
+
+	mcli := &kubernetes.Clientset{}
+	mcli.AddReactor("get", "services", func(action kubetesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("connection refused")
+	})
+
+	svc := k8s.NewServiceService(mcli, log.Dummy, metrics.Dummy)
+	err := svc.CreateOrUpdateService(testns, service)
+	assertTest.Error(err)
+	assertTest.Equal([]kubetesting.Action{newServiceGetAction(testns, service.Name)}, mcli.Actions())
+}
+
+func TestServiceServiceDeleteService(t *testing.T) {
+	testns := "testns"
+
+	t.Run("deletes an existing Service", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testsvc",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset(svc)
+		service := k8s.NewServiceService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteService(testns, "testsvc")
+		assertTest.NoError(err)
+
+		_, err = mcli.CoreV1().Services(testns).Get(context.TODO(), "testsvc", metav1.GetOptions{})
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+
+	t.Run("returns an error when deleting a non-existent Service", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewServiceService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteService(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+}
+
+func TestServiceServiceListServices(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	svc1 := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc1", Namespace: testns}}
+	svc2 := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc2", Namespace: testns}}
+	otherNsSvc := &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "svc3", Namespace: "otherns"}}
+
+	mcli := kubernetes.NewClientset(svc1, svc2, otherNsSvc)
+	service := k8s.NewServiceService(mcli, log.Dummy, metrics.Dummy)
+
+	list, err := service.ListServices(testns)
+	assertTest.NoError(err)
+	assertTest.Len(list.Items, 2)
+}
+
+func TestServiceServiceCreateIfNotExistsService(t *testing.T) {
+	testns := "testns"
+
+	t.Run("creates the service when it does not exist", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testsvc",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewServiceService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.CreateIfNotExistsService(testns, svc)
+		assertTest.NoError(err)
+
+		got, err := mcli.CoreV1().Services(testns).Get(context.TODO(), "testsvc", metav1.GetOptions{})
+		assertTest.NoError(err)
+		assertTest.Equal("testsvc", got.Name)
+	})
+
+	t.Run("does nothing when the service already exists", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testsvc",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset(svc)
+		service := k8s.NewServiceService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.CreateIfNotExistsService(testns, svc)
+		assertTest.NoError(err)
+	})
+
+	t.Run("returns a non-NotFound error from the get as-is", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		svc := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "testsvc",
+			},
+		}
+
+		mcli := &kubernetes.Clientset{}
+		mcli.AddReactor("get", "services", func(action kubetesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("connection refused")
+		})
+
+		service := k8s.NewServiceService(mcli, log.Dummy, metrics.Dummy)
+		err := service.CreateIfNotExistsService(testns, svc)
+		assertTest.Error(err)
+		assertTest.Equal([]kubetesting.Action{newServiceGetAction(testns, svc.Name)}, mcli.Actions())
+	})
 }

--- a/service/k8s/statefulset_test.go
+++ b/service/k8s/statefulset_test.go
@@ -1,6 +1,7 @@
 package k8s_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -364,4 +365,55 @@ func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
 			assertTest.NoError(err)
 		})
 	}
+}
+
+func TestStatefulSetServiceDeleteStatefulSet(t *testing.T) {
+	testns := "testns"
+
+	t.Run("deletes an existing StatefulSet", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		sts := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "teststatefulset",
+				Namespace: testns,
+			},
+		}
+		mcli := kubernetes.NewClientset(sts)
+		service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteStatefulSet(testns, "teststatefulset")
+		assertTest.NoError(err)
+
+		_, err = mcli.AppsV1().StatefulSets(testns).Get(context.TODO(), "teststatefulset", metav1.GetOptions{})
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+
+	t.Run("returns an error when deleting a non-existent StatefulSet", func(t *testing.T) {
+		assertTest := assert.New(t)
+
+		mcli := kubernetes.NewClientset()
+		service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
+
+		err := service.DeleteStatefulSet(testns, "does-not-exist")
+		assertTest.Error(err)
+		assertTest.True(kubeerrors.IsNotFound(err))
+	})
+}
+
+func TestStatefulSetServiceListStatefulSets(t *testing.T) {
+	assertTest := assert.New(t)
+	testns := "testns"
+
+	sts1 := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "sts1", Namespace: testns}}
+	sts2 := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "sts2", Namespace: testns}}
+	otherNsSts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "sts3", Namespace: "otherns"}}
+
+	mcli := kubernetes.NewClientset(sts1, sts2, otherNsSts)
+	service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
+
+	list, err := service.ListStatefulSets(testns)
+	assertTest.NoError(err)
+	assertTest.Len(list.Items, 2)
 }


### PR DESCRIPTION
## Summary

Raises unit test coverage in `service/k8s/` for four files, part of a larger parallel coverage push (this slice only touches the files below):

- `service/k8s/rbac.go` — added tests for `GetClusterRole`, `GetRole`, `DeleteRole`, `CreateRole`, `UpdateRole`, `CreateOrUpdateRole`, plus the missing error-path branches of `DeleteRoleBinding`, `UpdateRoleBinding`, `UpdateRole`, and `CreateOrUpdateRoleBinding` (non-NotFound get error, and delete failure during roleref-change recreation).
- `service/k8s/service.go` — added tests for `DeleteService`, `ListServices`, `CreateIfNotExistsService`, plus the missing non-NotFound get-error branch of `CreateOrUpdateService`.
- `service/k8s/statefulset.go` — added tests for `DeleteStatefulSet` and `ListStatefulSets`.
- `service/k8s/redisfailover.go` — **new** `redisfailover_test.go` (none existed) covering `ListRedisFailovers`, `WatchRedisFailovers`, and `UpdateRedisFailoverStatus`, using the repo's generated CRD fake clientset (`redisfailoverfake.NewSimpleClientset`).

All new tests mirror the existing table-driven / `testify`+`k8s.io/client-go/testing` action-assertion style already used in these files' sibling `_test.go` files, and use `kubernetes.NewClientset()` (not the deprecated `NewSimpleClientset`) where a real fake clientset is needed.

`service/k8s` package coverage: **72.0% → 88.3%**. Every function named in scope now reports 100% (`UpdateRole`, all RBAC CRUD/binding methods, `DeleteService`/`ListServices`/`CreateIfNotExistsService`/`CreateOrUpdateService`, `DeleteStatefulSet`/`ListStatefulSets`, and all three `RedisFailoverService` methods).

No production code was changed — only new/updated `_test.go` files.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./service/k8s/...` (all pass)
- [x] `go test ./...` (full suite passes)
- [x] `golangci-lint run --no-config ./service/k8s/...` (0 issues)


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_