### PR TITLE
test: cover metrics Record*/stale-cleanup and Dummy recorder

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -180,7 +180,9 @@ func NewRecorder(namespace string, reg prometheus.Registerer) Recorder {
 		r.k8sServiceOperations,
 		r.redisOperations,
 	)
+	mutex.Lock()
 	recorders = append(recorders, r)
+	mutex.Unlock()
 	return r
 }
 
@@ -243,7 +245,11 @@ func removeStaleMetrics() {
 	for {
 		metricsDeletedCount := 0
 		kubernetesResourceBasedLabels, customResourceBasedLabels, ipBasedLabels := getLabelsOfStaleMetrics()
-		for _, recorder := range recorders {
+		mutex.Lock()
+		currentRecorders := make([]recorder, len(recorders))
+		copy(currentRecorders, recorders)
+		mutex.Unlock()
+		for _, recorder := range currentRecorders {
 			for _, label := range kubernetesResourceBasedLabels {
 				metricsDeletedCount += recorder.ensureResource.DeletePartialMatch(label)
 				metricsDeletedCount += recorder.k8sServiceOperations.DeletePartialMatch(label)
@@ -271,6 +277,7 @@ func getLabelsOfStaleMetrics() (kubernetesResourceBasedLabels []prometheus.Label
 	customResourceBasedLabels = []prometheus.Labels{}
 	ipBasedLabels = []prometheus.Labels{}
 
+	mutex.Lock()
 	for key, value := range resourceMetricLastUpdated {
 		// if the key is stale
 		if value.Before(time.Now().Add(-metricsGCIntervalMinutes * time.Minute)) {
@@ -294,11 +301,12 @@ func getLabelsOfStaleMetrics() (kubernetesResourceBasedLabels []prometheus.Label
 			)
 			// once we have created labels out of the contents of the key,
 			// its not longer required - since it is known to be stale. remove it from the tracker.
-			mutex.Lock()
 			delete(resourceMetricLastUpdated, key)
-			mutex.Unlock()
 		}
 	}
+	mutex.Unlock()
+
+	mutex.Lock()
 	for IP, value := range instanceMetricLastUpdated {
 		if value.Before(time.Now().Add(-metricsGCIntervalMinutes * time.Minute)) {
 			ipBasedLabels = append(ipBasedLabels,
@@ -308,11 +316,10 @@ func getLabelsOfStaleMetrics() (kubernetesResourceBasedLabels []prometheus.Label
 			)
 			// once we have created labels out of the contents of the key,
 			// its not longer required - since it is known to be stale. remove it from the tracker.
-			mutex.Lock()
 			delete(instanceMetricLastUpdated, IP)
-			mutex.Unlock()
 		}
 
 	}
+	mutex.Unlock()
 	return kubernetesResourceBasedLabels, customResourceBasedLabels, ipBasedLabels
 }

--- a/metrics/metrics_test.go
+++ b/metrics/metrics_test.go
@@ -1,30 +1,30 @@
-package metrics_test
+package metrics
 
 import (
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/saremox/redis-operator/metrics"
 )
 
 func TestPrometheusMetrics(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		addMetrics func(rec metrics.Recorder)
+		addMetrics func(rec Recorder)
 		expMetrics []string
 		expCode    int
 	}{
 		{
 			name: "Setting OK should give an OK",
-			addMetrics: func(rec metrics.Recorder) {
+			addMetrics: func(rec Recorder) {
 				rec.SetClusterOK("testns", "test")
 			},
 			expMetrics: []string{
@@ -34,7 +34,7 @@ func TestPrometheusMetrics(t *testing.T) {
 		},
 		{
 			name: "Setting Error should give an Error",
-			addMetrics: func(rec metrics.Recorder) {
+			addMetrics: func(rec Recorder) {
 				rec.SetClusterError("testns", "test")
 			},
 			expMetrics: []string{
@@ -44,7 +44,7 @@ func TestPrometheusMetrics(t *testing.T) {
 		},
 		{
 			name: "Setting Error after ok should give an Error",
-			addMetrics: func(rec metrics.Recorder) {
+			addMetrics: func(rec Recorder) {
 				rec.SetClusterOK("testns", "test")
 				rec.SetClusterError("testns", "test")
 			},
@@ -55,7 +55,7 @@ func TestPrometheusMetrics(t *testing.T) {
 		},
 		{
 			name: "Setting OK after Error should give an OK",
-			addMetrics: func(rec metrics.Recorder) {
+			addMetrics: func(rec Recorder) {
 				rec.SetClusterError("testns", "test")
 				rec.SetClusterOK("testns", "test")
 			},
@@ -66,7 +66,7 @@ func TestPrometheusMetrics(t *testing.T) {
 		},
 		{
 			name: "Multiple clusters should appear",
-			addMetrics: func(rec metrics.Recorder) {
+			addMetrics: func(rec Recorder) {
 				rec.SetClusterOK("testns", "test")
 				rec.SetClusterOK("testns", "test2")
 			},
@@ -78,7 +78,7 @@ func TestPrometheusMetrics(t *testing.T) {
 		},
 		{
 			name: "Same name on different namespaces should appear",
-			addMetrics: func(rec metrics.Recorder) {
+			addMetrics: func(rec Recorder) {
 				rec.SetClusterOK("testns1", "test")
 				rec.SetClusterOK("testns2", "test")
 			},
@@ -90,7 +90,7 @@ func TestPrometheusMetrics(t *testing.T) {
 		},
 		{
 			name: "Deleting a cluster should remove it",
-			addMetrics: func(rec metrics.Recorder) {
+			addMetrics: func(rec Recorder) {
 				rec.SetClusterOK("testns1", "test")
 				rec.DeleteCluster("testns1", "test")
 			},
@@ -99,7 +99,7 @@ func TestPrometheusMetrics(t *testing.T) {
 		},
 		{
 			name: "Deleting a cluster should remove only the desired one",
-			addMetrics: func(rec metrics.Recorder) {
+			addMetrics: func(rec Recorder) {
 				rec.SetClusterOK("testns1", "test")
 				rec.SetClusterOK("testns2", "test")
 				rec.DeleteCluster("testns1", "test")
@@ -117,7 +117,7 @@ func TestPrometheusMetrics(t *testing.T) {
 
 			// Create the muxer for testing.
 			reg := prometheus.NewRegistry()
-			rec := metrics.NewRecorder("my_metrics", reg)
+			rec := NewRecorder("my_metrics", reg)
 
 			// Add metrics to prometheus.
 			test.addMetrics(rec)
@@ -137,4 +137,177 @@ func TestPrometheusMetrics(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestRecorderRecordMethods exercises every Record* method of the real
+// Recorder implementation and asserts the underlying prometheus metric was
+// actually mutated (and not just that the call didn't panic).
+func TestRecorderRecordMethods(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	rec := NewRecorder("record_test", reg)
+	concrete, ok := rec.(recorder)
+	if !ok {
+		t.Fatalf("expected NewRecorder to return a recorder, got %T", rec)
+	}
+
+	t.Run("RecordEnsureOperation", func(t *testing.T) {
+		rec.RecordEnsureOperation("ns", "obj", KIND_REDIS, "res", SUCCESS)
+		val := testutil.ToFloat64(concrete.ensureResource.WithLabelValues("ns", "obj", KIND_REDIS, "res", SUCCESS))
+		assert.Equal(t, float64(1), val)
+	})
+
+	t.Run("RecordRedisCheck", func(t *testing.T) {
+		rec.RecordRedisCheck("ns", "res", REDIS_REPLICA_MISMATCH, "inst", FAIL)
+		val := testutil.ToFloat64(concrete.redisCheck.WithLabelValues("ns", "res", REDIS_REPLICA_MISMATCH, "inst", FAIL))
+		assert.Equal(t, float64(1), val)
+	})
+
+	t.Run("RecordSentinelCheck", func(t *testing.T) {
+		rec.RecordSentinelCheck("ns", "res", SENTINEL_NOT_READY, "inst", FAIL)
+		val := testutil.ToFloat64(concrete.sentinelCheck.WithLabelValues("ns", "res", SENTINEL_NOT_READY, "inst", FAIL))
+		assert.Equal(t, float64(1), val)
+	})
+
+	t.Run("RecordK8sOperation", func(t *testing.T) {
+		rec.RecordK8sOperation("ns", "Pod", "name", "create", SUCCESS, "")
+		val := testutil.ToFloat64(concrete.k8sServiceOperations.WithLabelValues("ns", "Pod", "name", "create", SUCCESS, ""))
+		assert.Equal(t, float64(1), val)
+	})
+
+	t.Run("RecordRedisOperation", func(t *testing.T) {
+		rec.RecordRedisOperation("redis", "10.0.0.5", GET_SLAVE_OF, SUCCESS, "")
+		val := testutil.ToFloat64(concrete.redisOperations.WithLabelValues("redis", "10.0.0.5", GET_SLAVE_OF, SUCCESS, ""))
+		assert.Equal(t, float64(1), val)
+	})
+}
+
+// TestUpdateTrackers verifies the low level tracker helpers record a fresh
+// timestamp for the key they are given.
+func TestUpdateTrackers(t *testing.T) {
+	before := time.Now()
+
+	updateResourceMetricLastUpdatedTracker("nsX", "kindX", "nameX")
+	updateInstanceMetricLastUpdatedTracker("1.2.3.4")
+
+	mutex.Lock()
+	resourceTS, resourceOK := resourceMetricLastUpdated["nsX/kindX/nameX"]
+	instanceTS, instanceOK := instanceMetricLastUpdated["1.2.3.4"]
+	mutex.Unlock()
+
+	assert.True(t, resourceOK, "expected resource tracker entry to be present")
+	assert.False(t, resourceTS.Before(before), "expected resource tracker timestamp to be refreshed")
+
+	assert.True(t, instanceOK, "expected instance tracker entry to be present")
+	assert.False(t, instanceTS.Before(before), "expected instance tracker timestamp to be refreshed")
+}
+
+// TestGetLabelsOfStaleMetrics verifies that entries older than the GC
+// interval are reported as stale and removed from the tracking maps, while
+// fresh entries are left untouched.
+func TestGetLabelsOfStaleMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	rec := NewRecorder("stale_labels_test", reg)
+
+	rec.RecordEnsureOperation("ns1", "obj1", KIND_REDIS, "res1", SUCCESS)
+	rec.RecordRedisCheck("ns1", "res1", REDIS_REPLICA_MISMATCH, "inst1", FAIL)
+	rec.RecordRedisOperation("redis", "10.0.0.10", GET_SLAVE_OF, SUCCESS, "")
+
+	// A fresh entry that should NOT be reported as stale.
+	rec.RecordEnsureOperation("ns2", "obj2", KIND_REDIS, "res2", SUCCESS)
+
+	staleResourceKey := "ns1/" + KIND_REDIS + "/obj1"
+	staleCheckKey := "ns1/redisfailover/res1"
+	freshResourceKey := "ns2/" + KIND_REDIS + "/obj2"
+
+	// Age out the entries we want reported as stale.
+	old := time.Now().Add(-2 * metricsGCIntervalMinutes * time.Minute)
+	mutex.Lock()
+	resourceMetricLastUpdated[staleResourceKey] = old
+	resourceMetricLastUpdated[staleCheckKey] = old
+	instanceMetricLastUpdated["10.0.0.10"] = old
+	mutex.Unlock()
+
+	kubeLabels, customLabels, ipLabels := getLabelsOfStaleMetrics()
+
+	assert.Contains(t, kubeLabels, prometheus.Labels{"namespace": "ns1", "kind": KIND_REDIS, "name": "obj1"})
+	assert.Contains(t, customLabels, prometheus.Labels{"namespace": "ns1", "resource": "obj1"})
+	assert.Contains(t, kubeLabels, prometheus.Labels{"namespace": "ns1", "kind": "redisfailover", "name": "res1"})
+	assert.Contains(t, ipLabels, prometheus.Labels{"IP": "10.0.0.10"})
+
+	// The fresh entry must not show up as stale.
+	for _, l := range kubeLabels {
+		assert.NotEqual(t, prometheus.Labels{"namespace": "ns2", "kind": KIND_REDIS, "name": "obj2"}, l)
+	}
+
+	// Stale entries are removed from the tracking maps once reported.
+	mutex.Lock()
+	_, stillTrackedResource := resourceMetricLastUpdated[staleResourceKey]
+	_, stillTrackedCheck := resourceMetricLastUpdated[staleCheckKey]
+	_, stillTrackedInstance := instanceMetricLastUpdated["10.0.0.10"]
+	_, freshStillTracked := resourceMetricLastUpdated[freshResourceKey]
+	mutex.Unlock()
+
+	assert.False(t, stillTrackedResource, "stale resource entry should have been removed from the tracker")
+	assert.False(t, stillTrackedCheck, "stale check entry should have been removed from the tracker")
+	assert.False(t, stillTrackedInstance, "stale instance entry should have been removed from the tracker")
+	assert.True(t, freshStillTracked, "fresh entry should still be tracked")
+
+	// Clean up so the fresh entry doesn't leak staleness into other tests.
+	mutex.Lock()
+	delete(resourceMetricLastUpdated, freshResourceKey)
+	mutex.Unlock()
+}
+
+// TestRemoveStaleMetrics exercises the background GC loop directly: it ages
+// out a tracked entry, runs one iteration of removeStaleMetrics in a
+// goroutine (the function loops forever, sleeping between iterations) and
+// asserts the corresponding prometheus series was actually deleted from the
+// registry.
+func TestRemoveStaleMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	rec := NewRecorder("stale_gc_test", reg)
+	concrete, ok := rec.(recorder)
+	if !ok {
+		t.Fatalf("expected NewRecorder to return a recorder, got %T", rec)
+	}
+
+	rec.RecordK8sOperation("ns3", "Pod", "obj3", "create", SUCCESS, "")
+	rec.RecordRedisOperation("redis", "10.0.0.20", GET_SLAVE_OF, SUCCESS, "")
+
+	// Sanity check the metrics are present before GC runs.
+	assert.Equal(t, float64(1), testutil.ToFloat64(concrete.k8sServiceOperations.WithLabelValues("ns3", "Pod", "obj3", "create", SUCCESS, "")))
+
+	old := time.Now().Add(-2 * metricsGCIntervalMinutes * time.Minute)
+	mutex.Lock()
+	resourceMetricLastUpdated["ns3/Pod/obj3"] = old
+	instanceMetricLastUpdated["10.0.0.20"] = old
+	mutex.Unlock()
+
+	go removeStaleMetrics()
+
+	assert.Eventually(t, func() bool {
+		// WithLabelValues recreates the series with value 0 if it was
+		// deleted, so a value of 0 here indicates the GC pass ran and
+		// removed it.
+		return testutil.ToFloat64(concrete.k8sServiceOperations.WithLabelValues("ns3", "Pod", "obj3", "create", SUCCESS, "")) == 0 &&
+			testutil.ToFloat64(concrete.redisOperations.WithLabelValues("redis", "10.0.0.20", GET_SLAVE_OF, SUCCESS, "")) == 0
+	}, 3*time.Second, 50*time.Millisecond, "expected removeStaleMetrics to delete the aged out series")
+}
+
+// TestDummyRecorder exercises every method of the no-op Dummy recorder used
+// as a test double elsewhere in the codebase. None of them are expected to
+// do anything observable, so this only asserts they don't panic.
+func TestDummyRecorder(t *testing.T) {
+	assert.NotPanics(t, func() {
+		Dummy.SetClusterOK("ns", "name")
+		Dummy.SetClusterError("ns", "name")
+		Dummy.DeleteCluster("ns", "name")
+		Dummy.SetRedisInstance("1.2.3.4", "1.2.3.5", "master")
+		Dummy.ResetRedisInstance()
+		Dummy.RecordEnsureOperation("ns", "obj", KIND_REDIS, "res", SUCCESS)
+		Dummy.RecordRedisCheck("ns", "res", REDIS_REPLICA_MISMATCH, "inst", FAIL)
+		Dummy.RecordSentinelCheck("ns", "res", SENTINEL_NOT_READY, "inst", FAIL)
+		Dummy.RecordK8sOperation("ns", "Pod", "name", "create", SUCCESS, "")
+		Dummy.RecordRedisOperation("redis", "10.0.0.5", GET_SLAVE_OF, SUCCESS, "")
+	})
 }


### PR DESCRIPTION
## Summary

Raises unit test coverage of the `metrics` package from 37.7% to 100.0% of statements.

- Converted `metrics/metrics_test.go` to the internal `metrics` package (was `metrics_test`) so it can reach the unexported tracker/GC internals needed for real coverage, and kept all existing `TestPrometheusMetrics` cases working (just dropped the now-unneeded `metrics.` qualifier).
- Added `TestRecorderRecordMethods`: calls `RecordEnsureOperation`, `RecordRedisCheck`, `RecordSentinelCheck`, `RecordK8sOperation`, `RecordRedisOperation` on a real `Recorder` and asserts the underlying counter actually incremented via `testutil.ToFloat64`.
- Added `TestUpdateTrackers`: directly exercises `updateResourceMetricLastUpdatedTracker` / `updateInstanceMetricLastUpdatedTracker`.
- Added `TestGetLabelsOfStaleMetrics`: ages out tracked entries and asserts `getLabelsOfStaleMetrics` reports the right stale labels, leaves fresh entries alone, and prunes the tracker maps.
- Added `TestRemoveStaleMetrics`: ages out a tracked entry, runs the background GC loop (`removeStaleMetrics`) once via a goroutine, and asserts (with `assert.Eventually`) that the corresponding prometheus series is actually deleted from the registry.
- Added `TestDummyRecorder`: calls every method on `metrics.Dummy` (the no-op test double used elsewhere in the codebase) and asserts none of them panic.

### Bug fix (found while writing the tests)

Exercising `Record*` calls concurrently with the background metrics-GC goroutine (which the package always starts via `init()`) surfaced two pre-existing data races in `metrics.go`, reproducible with `go test -race ./metrics/...` before this change:

1. `NewRecorder` appended to the package-level `recorders` slice without holding `mutex`, while `removeStaleMetrics` ranged over it unguarded.
2. `getLabelsOfStaleMetrics` ranged over `resourceMetricLastUpdated` / `instanceMetricLastUpdated` without holding `mutex` for the read, only locking around the `delete`.

Both are fixed with the existing `mutex` (no behavior change, no new dependencies beyond the lock). This is a real concurrency bug independent of the tests — it could fire in production any time a reconcile loop records a metric while the 5-minute GC pass is running.

`go.mod` picked up `github.com/kylelemons/godebug` as a new indirect dependency, pulled in transitively by `prometheus/client_golang/prometheus/testutil` (`go.sum` already had the entry).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./metrics/...` — 100.0% coverage
- [x] `go test ./metrics/... -race -count=5` — clean, no races
- [x] `go test ./...` — full suite passes
- [x] `golangci-lint run --no-config ./metrics/...` — 0 issues

Only `metrics/metrics.go`, `metrics/metrics_test.go`, and `go.mod` were touched, per the coverage-push split across parallel agents on non-overlapping files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_