### PR TITLE
fix: two reconcile-loop status bugs + test coverage for checker/ensurer/handler

### DIFF
--- a/operator/redisfailover/checker.go
+++ b/operator/redisfailover/checker.go
@@ -516,6 +516,7 @@ func (r *RedisFailoverHandler) checkAndHealBootstrapMode(rf *redisfailoverv1.Red
 			State:   redisfailoverv1.NotHealthyState,
 			Message: "unable to update Redis PODs",
 		}
+		return err
 	}
 	err = r.applyRedisCustomConfig(rf)
 	setRedisCheckerMetrics(r.mClient, "redis", rf.Namespace, rf.Name, metrics.APPLY_REDIS_CONFIG, metrics.NOT_APPLICABLE, err)
@@ -600,6 +601,10 @@ func (r *RedisFailoverHandler) checkAndHealSentinels(rf *redisfailoverv1.RedisFa
 		if err != nil {
 			r.logger.WithField("redisfailover", rf.ObjectMeta.Name).WithField("namespace", rf.ObjectMeta.Namespace).Warningf("Sentinel %s mismatch number of sentinels in memory. resetting", sip)
 			if err := r.rfHealer.RestoreSentinel(sip); err != nil {
+				rf.Status = redisfailoverv1.RedisFailoverStatus{
+					State:   redisfailoverv1.NotHealthyState,
+					Message: "unable to restore sentinel",
+				}
 				return err
 			}
 		}
@@ -611,6 +616,10 @@ func (r *RedisFailoverHandler) checkAndHealSentinels(rf *redisfailoverv1.RedisFa
 		if err != nil {
 			r.logger.WithField("redisfailover", rf.ObjectMeta.Name).WithField("namespace", rf.ObjectMeta.Namespace).Warningf("Sentinel %s mismatch number of expected slaves in memory. resetting", sip)
 			if err := r.rfHealer.RestoreSentinel(sip); err != nil {
+				rf.Status = redisfailoverv1.RedisFailoverStatus{
+					State:   redisfailoverv1.NotHealthyState,
+					Message: "unable to restore sentinel",
+				}
 				return err
 			}
 		}
@@ -619,6 +628,10 @@ func (r *RedisFailoverHandler) checkAndHealSentinels(rf *redisfailoverv1.RedisFa
 		err := r.rfHealer.SetSentinelCustomConfig(sip, rf)
 		setRedisCheckerMetrics(r.mClient, "sentinel", rf.Namespace, rf.Name, metrics.APPLY_SENTINEL_CONFIG, sip, err)
 		if err != nil {
+			rf.Status = redisfailoverv1.RedisFailoverStatus{
+				State:   redisfailoverv1.NotHealthyState,
+				Message: "unable to set sentinel custom config",
+			}
 			return err
 		}
 	}

--- a/operator/redisfailover/checker_test.go
+++ b/operator/redisfailover/checker_test.go
@@ -1029,11 +1029,11 @@ func TestCheckAndHealPlainModeErrorBranches(t *testing.T) {
 		},
 		{
 			// checkAndHealSentinels (called as the final statement of
-			// CheckAndHeal) does not set rf.Status on error, unlike every
-			// preceding branch in CheckAndHeal - see the note in the test
-			// body below and the final report for details. This test
-			// documents the actual observed behavior; it does not assert
-			// that behavior is correct.
+			// CheckAndHeal) used to return errors without setting rf.Status,
+			// unlike every preceding branch in CheckAndHeal - the HealthyState
+			// set at the top would stick despite the reconcile actually
+			// failing. Fixed to set NotHealthyState on each error path,
+			// matching the rest of the file.
 			name: "sentinel number-in-memory mismatch - RestoreSentinel fails",
 			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
 				mrfc.On("IsRedisRunning", rf).Once().Return(true)
@@ -1054,13 +1054,9 @@ func TestCheckAndHealPlainModeErrorBranches(t *testing.T) {
 				mrfc.On("CheckSentinelNumberInMemory", sentinel, rf).Once().Return(errors.New("mismatch"))
 				mrfh.On("RestoreSentinel", sentinel).Once().Return(errors.New("restore err"))
 			},
-			wantErr: true,
-			// NOTE: unlike every other CheckAndHeal error branch, the
-			// rf.Status set at the top of CheckAndHeal (HealthyState) is
-			// never overwritten here - checkAndHealSentinels returns the
-			// error directly without touching rf.Status. See suspected-bug
-			// notes in this PR.
-			wantState: v1.HealthyState,
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to restore sentinel",
 		},
 		{
 			name: "sentinel slaves-number-in-memory mismatch - RestoreSentinel fails",
@@ -1084,8 +1080,9 @@ func TestCheckAndHealPlainModeErrorBranches(t *testing.T) {
 				mrfc.On("CheckSentinelSlavesNumberInMemory", sentinel, rf).Once().Return(errors.New("mismatch"))
 				mrfh.On("RestoreSentinel", sentinel).Once().Return(errors.New("restore err"))
 			},
-			wantErr:   true,
-			wantState: v1.HealthyState, // see note above
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to restore sentinel",
 		},
 		{
 			name: "SetSentinelCustomConfig fails",
@@ -1109,8 +1106,9 @@ func TestCheckAndHealPlainModeErrorBranches(t *testing.T) {
 				mrfc.On("CheckSentinelSlavesNumberInMemory", sentinel, rf).Once().Return(nil)
 				mrfh.On("SetSentinelCustomConfig", sentinel, rf).Once().Return(errors.New("set config err"))
 			},
-			wantErr:   true,
-			wantState: v1.HealthyState, // see note above
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to set sentinel custom config",
 		},
 	}
 
@@ -1186,27 +1184,18 @@ func TestCheckAndHealBootstrapModeErrorBranches(t *testing.T) {
 	}{
 		{
 			// checkAndHealBootstrapMode's UpdateRedisesPods error handling
-			// (checker.go) sets rf.Status to NotHealthyState but, unlike
-			// every other error branch in this file, does not `return err`
-			// afterwards - execution falls through into
-			// applyRedisCustomConfig and beyond. If the rest of the
-			// function then succeeds, CheckAndHeal reports success (nil
-			// error) while rf.Status is left claiming NotHealthyState with
-			// this stale message. This test documents that actual,
-			// suspected-buggy behavior (see the PR description / final
-			// report) - it is not asserting that behavior is correct.
-			name: "UpdateRedisesPods fails but error is swallowed (suspected bug)",
+			// used to set rf.Status to NotHealthyState without a `return
+			// err` afterwards, unlike every other error branch in this
+			// file - execution fell through into applyRedisCustomConfig
+			// and beyond, so a real failure here could be swallowed and
+			// reported as success. Fixed to return immediately, matching
+			// every other branch; this now asserts the fixed behavior.
+			name: "UpdateRedisesPods fails",
 			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
 				mrfc.On("IsRedisRunning", rf).Once().Return(true)
-				// UpdateRedisesPods' own GetRedisesIPs call fails...
 				mrfc.On("GetRedisesIPs", rf).Once().Return(nil, errors.New("update pods ips err"))
-				// ...but applyRedisCustomConfig's independent call (and the
-				// rest of the function) still runs and succeeds.
-				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{bootstrapMaster}, nil)
-				mrfh.On("SetRedisCustomConfig", bootstrapMaster, rf).Once().Return(nil)
-				mrfh.On("SetExternalMasterOnAll", bootstrapMaster, bootstrapMasterPort, rf).Once().Return(nil)
 			},
-			wantErr:     false,
+			wantErr:     true,
 			wantState:   v1.NotHealthyState,
 			wantMessage: "unable to update Redis PODs",
 		},

--- a/operator/redisfailover/checker_test.go
+++ b/operator/redisfailover/checker_test.go
@@ -757,6 +757,555 @@ func TestCheckAndHealOperatorManagedMode(t *testing.T) {
 	}
 }
 
+// TestCheckAndHealPlainModeErrorBranches exercises early-return error
+// branches of CheckAndHeal (operator/redisfailover/checker.go) in the
+// "plain" (non-bootstrapping, Sentinel-managed) mode that the large
+// table-driven TestCheckAndHeal above does not reach - mostly sub-call
+// errors that TestCheckAndHeal's table always configures to succeed.
+func TestCheckAndHealPlainModeErrorBranches(t *testing.T) {
+	const (
+		master   = "0.0.0.0"
+		sentinel = "1.1.1.1"
+		port     = "0" // getRedisPort(rf.Spec.Redis.Port) with the zero-value Port used by generateRF
+	)
+
+	tests := []struct {
+		name        string
+		rfMod       func(rf *v1.RedisFailover)
+		setup       func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover)
+		wantErr     bool
+		wantState   string
+		wantMessage string
+	}{
+		{
+			name: "redis not running - waits for statefulset reconcile",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(false)
+			},
+			wantErr:     false,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "not all replicas running",
+		},
+		{
+			name: "sentinel not running - waits for deployment reconcile",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(false)
+			},
+			wantErr:     false,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "not all replicas running",
+		},
+		{
+			name: "GetNumberMasters errors",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(0, errors.New("num masters err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to get number of masters",
+		},
+		{
+			name: "no master, single replica - SetOldestAsMaster fails",
+			rfMod: func(rf *v1.RedisFailover) {
+				rf.Spec.Redis.Replicas = 1
+			},
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(0, nil)
+				mrfh.On("SetOldestAsMaster", rf).Once().Return(errors.New("oldest err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "Error in Setting oldest Pod as master",
+		},
+		{
+			name: "no master - GetMaxRedisPodTime fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(0, nil)
+				mrfc.On("GetMaxRedisPodTime", rf).Once().Return(time.Duration(0), errors.New("uptime err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to get Redis POD time",
+		},
+		{
+			name: "no master, no quorum - SetOldestAsMaster fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(0, nil)
+				mrfc.On("GetMaxRedisPodTime", rf).Once().Return(1*time.Hour, nil)
+				mrfc.On("CheckSentinelQuorum", rf).Once().Return(1, errors.New("no quorum"))
+				mrfh.On("SetOldestAsMaster", rf).Once().Return(errors.New("oldest err2"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "Error in Setting oldest Pod as master",
+		},
+		{
+			name: "no master, has quorum - CheckIfMasterLocalhost fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(0, nil)
+				mrfc.On("GetMaxRedisPodTime", rf).Once().Return(1*time.Hour, nil)
+				mrfc.On("CheckSentinelQuorum", rf).Once().Return(3, nil)
+				mrfc.On("CheckIfMasterLocalhost", rf).Once().Return(false, errors.New("localhost check err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to check if master localhost",
+		},
+		{
+			name: "no master, has quorum, localhost true - SetOldestAsMaster fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(0, nil)
+				mrfc.On("GetMaxRedisPodTime", rf).Once().Return(1*time.Hour, nil)
+				mrfc.On("CheckSentinelQuorum", rf).Once().Return(3, nil)
+				mrfc.On("CheckIfMasterLocalhost", rf).Once().Return(true, nil)
+				mrfh.On("SetOldestAsMaster", rf).Once().Return(errors.New("oldest err3"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "Error in Setting oldest Pod as master",
+		},
+		{
+			name: "single master - GetMasterIP fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return("", errors.New("master ip err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to get master IP",
+		},
+		{
+			name: "slaves wrong - re-verifying master IP fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(errors.New("wrong master"))
+				mrfc.On("GetMasterIP", rf).Once().Return("", errors.New("reverify err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to re-verify master IP",
+		},
+		{
+			name: "slaves wrong - SetMasterOnAll fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(errors.New("wrong master"))
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfh.On("SetMasterOnAll", master, rf).Once().Return(errors.New("set fail"))
+			},
+			wantErr:   true,
+			wantState: v1.NotHealthyState,
+			// This branch (checker.go's SetMasterOnAll error handling) sets
+			// only State, not Message - unlike almost every other error
+			// branch in CheckAndHeal.
+			wantMessage: "",
+		},
+		{
+			name: "applyRedisCustomConfig fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(nil)
+				// applyRedisCustomConfig's own GetRedisesIPs error branch.
+				mrfc.On("GetRedisesIPs", rf).Once().Return(nil, errors.New("ips err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to apply custom config",
+		},
+		{
+			name: "UpdateRedisesPods fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(nil)
+				// First GetRedisesIPs call is applyRedisCustomConfig's (succeeds);
+				// second is UpdateRedisesPods' own call (fails).
+				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{master}, nil)
+				mrfh.On("SetRedisCustomConfig", master, rf).Once().Return(nil)
+				mrfc.On("GetRedisesIPs", rf).Once().Return(nil, errors.New("update pods ips err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to update redis PODs",
+		},
+		{
+			name: "GetSentinelsIPs fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(nil)
+				mrfc.On("GetRedisesIPs", rf).Twice().Return([]string{master}, nil)
+				mrfh.On("SetRedisCustomConfig", master, rf).Once().Return(nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfc.On("GetRedisesMasterPod", rf).Once().Return(master, nil)
+				mrfc.On("GetRedisRevisionHash", master, rf).Once().Return("1", nil)
+				// UpdateRedisesPods' own internal GetMasterIP call (it is not
+				// bootstrapping, so it resolves masterIP itself, ignoring errors).
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetSentinelsIPs", rf).Once().Return(nil, errors.New("sentinels ips err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to get sentinels IPs",
+		},
+		{
+			name: "sentinel monitor wrong - re-verifying master IP fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(nil)
+				mrfc.On("GetRedisesIPs", rf).Twice().Return([]string{master}, nil)
+				mrfh.On("SetRedisCustomConfig", master, rf).Once().Return(nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfc.On("GetRedisesMasterPod", rf).Once().Return(master, nil)
+				mrfc.On("GetRedisRevisionHash", master, rf).Once().Return("1", nil)
+				// UpdateRedisesPods' own internal GetMasterIP call.
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetSentinelsIPs", rf).Once().Return([]string{sentinel}, nil)
+				mrfc.On("CheckSentinelMonitor", sentinel, master, port).Once().Return(errors.New("mon err"))
+				mrfc.On("GetMasterIP", rf).Once().Return("", errors.New("reverify master err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to re-verify master IP",
+		},
+		{
+			name: "sentinel monitor wrong - NewSentinelMonitor fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(nil)
+				mrfc.On("GetRedisesIPs", rf).Twice().Return([]string{master}, nil)
+				mrfh.On("SetRedisCustomConfig", master, rf).Once().Return(nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfc.On("GetRedisesMasterPod", rf).Once().Return(master, nil)
+				mrfc.On("GetRedisRevisionHash", master, rf).Once().Return("1", nil)
+				// UpdateRedisesPods' own internal GetMasterIP call.
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetSentinelsIPs", rf).Once().Return([]string{sentinel}, nil)
+				mrfc.On("CheckSentinelMonitor", sentinel, master, port).Once().Return(errors.New("mon err"))
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfh.On("NewSentinelMonitor", sentinel, master, rf).Once().Return(errors.New("new monitor err"))
+			},
+			wantErr:   true,
+			wantState: v1.NotHealthyState,
+			// Same as the SetMasterOnAll branch above: only State is set.
+			wantMessage: "",
+		},
+		{
+			// checkAndHealSentinels (called as the final statement of
+			// CheckAndHeal) does not set rf.Status on error, unlike every
+			// preceding branch in CheckAndHeal - see the note in the test
+			// body below and the final report for details. This test
+			// documents the actual observed behavior; it does not assert
+			// that behavior is correct.
+			name: "sentinel number-in-memory mismatch - RestoreSentinel fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(nil)
+				mrfc.On("GetRedisesIPs", rf).Twice().Return([]string{master}, nil)
+				mrfh.On("SetRedisCustomConfig", master, rf).Once().Return(nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfc.On("GetRedisesMasterPod", rf).Once().Return(master, nil)
+				mrfc.On("GetRedisRevisionHash", master, rf).Once().Return("1", nil)
+				// UpdateRedisesPods' own internal GetMasterIP call.
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetSentinelsIPs", rf).Once().Return([]string{sentinel}, nil)
+				mrfc.On("CheckSentinelMonitor", sentinel, master, port).Once().Return(nil)
+				mrfc.On("CheckSentinelNumberInMemory", sentinel, rf).Once().Return(errors.New("mismatch"))
+				mrfh.On("RestoreSentinel", sentinel).Once().Return(errors.New("restore err"))
+			},
+			wantErr: true,
+			// NOTE: unlike every other CheckAndHeal error branch, the
+			// rf.Status set at the top of CheckAndHeal (HealthyState) is
+			// never overwritten here - checkAndHealSentinels returns the
+			// error directly without touching rf.Status. See suspected-bug
+			// notes in this PR.
+			wantState: v1.HealthyState,
+		},
+		{
+			name: "sentinel slaves-number-in-memory mismatch - RestoreSentinel fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(nil)
+				mrfc.On("GetRedisesIPs", rf).Twice().Return([]string{master}, nil)
+				mrfh.On("SetRedisCustomConfig", master, rf).Once().Return(nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfc.On("GetRedisesMasterPod", rf).Once().Return(master, nil)
+				mrfc.On("GetRedisRevisionHash", master, rf).Once().Return("1", nil)
+				// UpdateRedisesPods' own internal GetMasterIP call.
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetSentinelsIPs", rf).Once().Return([]string{sentinel}, nil)
+				mrfc.On("CheckSentinelMonitor", sentinel, master, port).Once().Return(nil)
+				mrfc.On("CheckSentinelNumberInMemory", sentinel, rf).Once().Return(nil)
+				mrfc.On("CheckSentinelSlavesNumberInMemory", sentinel, rf).Once().Return(errors.New("mismatch"))
+				mrfh.On("RestoreSentinel", sentinel).Once().Return(errors.New("restore err"))
+			},
+			wantErr:   true,
+			wantState: v1.HealthyState, // see note above
+		},
+		{
+			name: "SetSentinelCustomConfig fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetNumberMasters", rf).Once().Return(1, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckAllSlavesFromMaster", master, rf).Once().Return(nil)
+				mrfc.On("GetRedisesIPs", rf).Twice().Return([]string{master}, nil)
+				mrfh.On("SetRedisCustomConfig", master, rf).Once().Return(nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfc.On("GetRedisesMasterPod", rf).Once().Return(master, nil)
+				mrfc.On("GetRedisRevisionHash", master, rf).Once().Return("1", nil)
+				// UpdateRedisesPods' own internal GetMasterIP call.
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetSentinelsIPs", rf).Once().Return([]string{sentinel}, nil)
+				mrfc.On("CheckSentinelMonitor", sentinel, master, port).Once().Return(nil)
+				mrfc.On("CheckSentinelNumberInMemory", sentinel, rf).Once().Return(nil)
+				mrfc.On("CheckSentinelSlavesNumberInMemory", sentinel, rf).Once().Return(nil)
+				mrfh.On("SetSentinelCustomConfig", sentinel, rf).Once().Return(errors.New("set config err"))
+			},
+			wantErr:   true,
+			wantState: v1.HealthyState, // see note above
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertTest := assert.New(t)
+
+			rf := generateRF(false, false)
+			if test.rfMod != nil {
+				test.rfMod(rf)
+			}
+
+			config := generateConfig()
+			mk := &mK8SService.Services{}
+			mrfs := &mRFService.RedisFailoverClient{}
+			mrfc := &mRFService.RedisFailoverCheck{}
+			mrfh := &mRFService.RedisFailoverHeal{}
+
+			test.setup(mrfc, mrfh, rf)
+
+			handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
+			err := handler.CheckAndHeal(rf)
+
+			if test.wantErr {
+				assertTest.Error(err)
+			} else {
+				assertTest.NoError(err)
+			}
+			assertTest.Equal(test.wantState, rf.Status.State)
+			if test.wantMessage != "" {
+				assertTest.Equal(test.wantMessage, rf.Status.Message)
+			}
+
+			mrfc.AssertExpectations(t)
+			mrfh.AssertExpectations(t)
+		})
+	}
+}
+
+// TestCheckAndHealBootstrapModeErrorBranches exercises early-return error
+// branches of checkAndHealBootstrapMode (operator/redisfailover/checker.go)
+// not already covered by the "Bootstrapping Mode..." cases in the
+// TestCheckAndHeal table above.
+func TestCheckAndHealBootstrapModeErrorBranches(t *testing.T) {
+	const (
+		bootstrapMaster     = "127.0.0.1"
+		bootstrapMasterPort = "6379"
+		sentinel            = "1.1.1.1"
+	)
+
+	// setupUpdateAndConfigSuccess wires up a full, successful pass through
+	// UpdateRedisesPods and applyRedisCustomConfig for the given redis IPs,
+	// as checkAndHealBootstrapMode calls them (masterIP stays "" while
+	// bootstrapping, so every IP is treated as a slave needing a
+	// CheckRedisSlavesReady call).
+	setupUpdateAndConfigSuccess := func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover, ips []string) {
+		mrfc.On("GetRedisesIPs", rf).Twice().Return(ips, nil)
+		for _, ip := range ips {
+			mrfc.On("CheckRedisSlavesReady", ip, rf).Once().Return(true, nil)
+			mrfh.On("SetRedisCustomConfig", ip, rf).Once().Return(nil)
+		}
+		mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+		mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+	}
+
+	tests := []struct {
+		name           string
+		allowSentinels bool
+		setup          func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover)
+		wantErr        bool
+		wantState      string
+		wantMessage    string
+	}{
+		{
+			// checkAndHealBootstrapMode's UpdateRedisesPods error handling
+			// (checker.go) sets rf.Status to NotHealthyState but, unlike
+			// every other error branch in this file, does not `return err`
+			// afterwards - execution falls through into
+			// applyRedisCustomConfig and beyond. If the rest of the
+			// function then succeeds, CheckAndHeal reports success (nil
+			// error) while rf.Status is left claiming NotHealthyState with
+			// this stale message. This test documents that actual,
+			// suspected-buggy behavior (see the PR description / final
+			// report) - it is not asserting that behavior is correct.
+			name: "UpdateRedisesPods fails but error is swallowed (suspected bug)",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				// UpdateRedisesPods' own GetRedisesIPs call fails...
+				mrfc.On("GetRedisesIPs", rf).Once().Return(nil, errors.New("update pods ips err"))
+				// ...but applyRedisCustomConfig's independent call (and the
+				// rest of the function) still runs and succeeds.
+				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{bootstrapMaster}, nil)
+				mrfh.On("SetRedisCustomConfig", bootstrapMaster, rf).Once().Return(nil)
+				mrfh.On("SetExternalMasterOnAll", bootstrapMaster, bootstrapMasterPort, rf).Once().Return(nil)
+			},
+			wantErr:     false,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to update Redis PODs",
+		},
+		{
+			name: "applyRedisCustomConfig fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				ips := []string{"1.1.1.1", "1.1.1.2", "1.1.1.3"}
+				mrfc.On("GetRedisesIPs", rf).Twice().Return(ips, nil)
+				for _, ip := range ips {
+					mrfc.On("CheckRedisSlavesReady", ip, rf).Once().Return(true, nil)
+				}
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfh.On("SetRedisCustomConfig", "1.1.1.1", rf).Once().Return(errors.New("cfg err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to set Redis custom config",
+		},
+		{
+			name:           "sentinels allowed but not running",
+			allowSentinels: true,
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				setupUpdateAndConfigSuccess(mrfc, mrfh, rf, []string{bootstrapMaster})
+				mrfh.On("SetExternalMasterOnAll", bootstrapMaster, bootstrapMasterPort, rf).Once().Return(nil)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(false)
+			},
+			wantErr:     false,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "not all replicas running",
+		},
+		{
+			name:           "sentinels allowed - GetSentinelsIPs fails",
+			allowSentinels: true,
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				setupUpdateAndConfigSuccess(mrfc, mrfh, rf, []string{bootstrapMaster})
+				mrfh.On("SetExternalMasterOnAll", bootstrapMaster, bootstrapMasterPort, rf).Once().Return(nil)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetSentinelsIPs", rf).Once().Return(nil, errors.New("sentinels ips err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to get sentinels IPs",
+		},
+		{
+			name:           "sentinels allowed - NewSentinelMonitorWithPort fails",
+			allowSentinels: true,
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("IsRedisRunning", rf).Once().Return(true)
+				setupUpdateAndConfigSuccess(mrfc, mrfh, rf, []string{bootstrapMaster})
+				mrfh.On("SetExternalMasterOnAll", bootstrapMaster, bootstrapMasterPort, rf).Once().Return(nil)
+				mrfc.On("IsSentinelRunning", rf).Once().Return(true)
+				mrfc.On("GetSentinelsIPs", rf).Once().Return([]string{sentinel}, nil)
+				mrfc.On("CheckSentinelMonitor", sentinel, bootstrapMaster, bootstrapMasterPort).Once().Return(errors.New("mon err"))
+				mrfh.On("NewSentinelMonitorWithPort", sentinel, bootstrapMaster, bootstrapMasterPort, rf).Once().Return(errors.New("new monitor err"))
+			},
+			wantErr:     true,
+			wantState:   v1.NotHealthyState,
+			wantMessage: "unable to check sentinel monitor",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertTest := assert.New(t)
+
+			rf := generateRF(false, true)
+			rf.Spec.BootstrapNode.AllowSentinels = test.allowSentinels
+
+			config := generateConfig()
+			mk := &mK8SService.Services{}
+			mrfs := &mRFService.RedisFailoverClient{}
+			mrfc := &mRFService.RedisFailoverCheck{}
+			mrfh := &mRFService.RedisFailoverHeal{}
+
+			test.setup(mrfc, mrfh, rf)
+
+			handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
+			err := handler.CheckAndHeal(rf)
+
+			if test.wantErr {
+				assertTest.Error(err)
+			} else {
+				assertTest.NoError(err)
+			}
+			assertTest.Equal(test.wantState, rf.Status.State)
+			if test.wantMessage != "" {
+				assertTest.Equal(test.wantMessage, rf.Status.Message)
+			}
+
+			mrfc.AssertExpectations(t)
+			mrfh.AssertExpectations(t)
+		})
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	type podStatus struct {
 		pod    corev1.Pod
@@ -1271,6 +1820,114 @@ func TestUpdate(t *testing.T) {
 			mrfc.AssertExpectations(t)
 			mrfh.AssertExpectations(t)
 
+		})
+	}
+}
+
+// TestUpdateRedisesPodsErrorBranches exercises the remaining early-return
+// error branches of UpdateRedisesPods (operator/redisfailover/checker.go)
+// not already covered by TestUpdate above: every sub-call it makes can
+// fail, and it must stop and propagate the error immediately.
+func TestUpdateRedisesPodsErrorBranches(t *testing.T) {
+	const (
+		slave  = "1.1.1.1"
+		master = "2.2.2.2"
+	)
+
+	tests := []struct {
+		name  string
+		setup func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover)
+	}{
+		{
+			name: "GetRedisesIPs fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("GetRedisesIPs", rf).Once().Return(nil, errors.New("ips err"))
+			},
+		},
+		{
+			name: "CheckRedisSlavesReady fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{slave, master}, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("CheckRedisSlavesReady", slave, rf).Once().Return(false, errors.New("check err"))
+			},
+		},
+		{
+			name: "GetRedisesSlavesPods fails",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{master}, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return(nil, errors.New("slaves pods err"))
+			},
+		},
+		{
+			name: "GetRedisRevisionHash fails for a slave pod",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{master}, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{"slave1"}, nil)
+				mrfc.On("GetRedisRevisionHash", "slave1", rf).Once().Return("", errors.New("revision err"))
+			},
+		},
+		{
+			name: "DeletePod fails for a stale slave pod",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{master}, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{"slave1"}, nil)
+				mrfc.On("GetRedisRevisionHash", "slave1", rf).Once().Return("stale", nil)
+				mrfh.On("DeletePod", "slave1", rf).Once().Return(errors.New("delete err"))
+			},
+		},
+		{
+			name: "GetRedisRevisionHash fails for the master pod",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{master}, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfc.On("GetRedisesMasterPod", rf).Once().Return(master, nil)
+				mrfc.On("GetRedisRevisionHash", master, rf).Once().Return("", errors.New("master revision err"))
+			},
+		},
+		{
+			name: "DeletePod fails for a stale master pod",
+			setup: func(mrfc *mRFService.RedisFailoverCheck, mrfh *mRFService.RedisFailoverHeal, rf *v1.RedisFailover) {
+				mrfc.On("GetRedisesIPs", rf).Once().Return([]string{master}, nil)
+				mrfc.On("GetMasterIP", rf).Once().Return(master, nil)
+				mrfc.On("GetStatefulSetUpdateRevision", rf).Once().Return("1", nil)
+				mrfc.On("GetRedisesSlavesPods", rf).Once().Return([]string{}, nil)
+				mrfc.On("GetRedisesMasterPod", rf).Once().Return(master, nil)
+				mrfc.On("GetRedisRevisionHash", master, rf).Once().Return("stale", nil)
+				mrfh.On("DeletePod", master, rf).Once().Return(errors.New("delete master err"))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assertTest := assert.New(t)
+
+			rf := generateRF(false, false)
+
+			config := generateConfig()
+			mk := &mK8SService.Services{}
+			mrfs := &mRFService.RedisFailoverClient{}
+			mrfc := &mRFService.RedisFailoverCheck{}
+			mrfh := &mRFService.RedisFailoverHeal{}
+
+			test.setup(mrfc, mrfh, rf)
+
+			handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
+			err := handler.UpdateRedisesPods(rf)
+
+			assertTest.Error(err)
+
+			mrfc.AssertExpectations(t)
+			mrfh.AssertExpectations(t)
 		})
 	}
 }

--- a/operator/redisfailover/ensurer_test.go
+++ b/operator/redisfailover/ensurer_test.go
@@ -1,6 +1,7 @@
 package redisfailover_test
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -136,6 +137,120 @@ func TestEnsure(t *testing.T) {
 			err := handler.Ensure(rf, map[string]string{}, []metav1.OwnerReference{}, metrics.Dummy)
 
 			assert.NoError(err)
+			mrfs.AssertExpectations(t)
+		})
+	}
+}
+
+// ensureStepSetup returns a closure that registers the mock expectation for
+// the named Ensure* / EnsureNotPresent* call performed by Ensure() in
+// ensurer.go, returning the given error (nil for a success stub).
+func ensureStepSetup(step string) func(m *mRFService.RedisFailoverClient, rf *redisfailoverv1.RedisFailover, err error) {
+	// Calls taking only rf (the "NotPresent" cleanup calls).
+	rfOnly := map[string]bool{
+		"EnsureNotPresentRedisService":      true,
+		"EnsureNotPresentSentinelResources": true,
+	}
+	if rfOnly[step] {
+		return func(m *mRFService.RedisFailoverClient, rf *redisfailoverv1.RedisFailover, err error) {
+			m.On(step, rf).Once().Return(err)
+		}
+	}
+	return func(m *mRFService.RedisFailoverClient, rf *redisfailoverv1.RedisFailover, err error) {
+		m.On(step, rf, mock.Anything, mock.Anything).Once().Return(err)
+	}
+}
+
+// TestEnsureErrorBranches exercises every early-return error branch in
+// Ensure() (operator/redisfailover/ensurer.go): each of the EnsureX /
+// EnsureNotPresentX calls it makes can fail, and Ensure() must stop and
+// propagate that error immediately without invoking any of the calls that
+// would normally follow. Two RF configurations are used because several
+// steps are mutually exclusive depending on exporter/sentinel settings:
+//   - modeA (exporter enabled, sentinels allowed) walks the "everything is
+//     enabled" branch of every either/or pair.
+//   - modeB (exporter disabled, sentinels disabled) walks the "cleanup"
+//     branch of the same either/or pairs.
+func TestEnsureErrorBranches(t *testing.T) {
+	modeA := []string{
+		"EnsureRedisService",
+		"EnsureSentinelService",
+		"EnsureSentinelConfigMap",
+		"EnsureRedisMasterService",
+		"EnsureRedisSlaveService",
+		"EnsureRedisShutdownConfigMap",
+		"EnsureRedisReadinessConfigMap",
+		"EnsureRedisConfigMap",
+		"EnsureRedisStatefulset",
+		"EnsureSentinelDeployment",
+	}
+	modeB := []string{
+		"EnsureNotPresentRedisService",
+		"EnsureNotPresentSentinelResources",
+		"EnsureRedisMasterService",
+		"EnsureRedisSlaveService",
+		"EnsureRedisShutdownConfigMap",
+		"EnsureRedisReadinessConfigMap",
+		"EnsureRedisConfigMap",
+		"EnsureRedisStatefulset",
+	}
+
+	tests := []struct {
+		name             string
+		exporter         bool
+		sentinelsAllowed bool
+		steps            []string
+		failAt           int
+	}{
+		{"EnsureRedisService fails", true, true, modeA, 0},
+		{"EnsureSentinelService fails", true, true, modeA, 1},
+		{"EnsureSentinelConfigMap fails", true, true, modeA, 2},
+		{"EnsureRedisMasterService fails", true, true, modeA, 3},
+		{"EnsureRedisSlaveService fails", true, true, modeA, 4},
+		{"EnsureRedisShutdownConfigMap fails", true, true, modeA, 5},
+		{"EnsureRedisReadinessConfigMap fails", true, true, modeA, 6},
+		{"EnsureRedisConfigMap fails", true, true, modeA, 7},
+		{"EnsureRedisStatefulset fails", true, true, modeA, 8},
+		{"EnsureSentinelDeployment fails", true, true, modeA, 9},
+		{"EnsureNotPresentRedisService fails", false, false, modeB, 0},
+		{"EnsureNotPresentSentinelResources fails", false, false, modeB, 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rf := generateRF(test.exporter, false)
+			if !test.sentinelsAllowed {
+				disabled := false
+				rf.Spec.Sentinel.Enabled = &disabled
+			}
+
+			config := generateConfig()
+			mk := &mK8SService.Services{}
+			mrfc := &mRFService.RedisFailoverCheck{}
+			mrfh := &mRFService.RedisFailoverHeal{}
+			mrfs := &mRFService.RedisFailoverClient{}
+
+			wantErr := errors.New(test.steps[test.failAt] + " failed")
+			for i, step := range test.steps {
+				if i > test.failAt {
+					// Steps after the failure must never be called: leave
+					// them unmocked so an unexpected call fails the test.
+					break
+				}
+				setup := ensureStepSetup(step)
+				if i == test.failAt {
+					setup(mrfs, rf, wantErr)
+				} else {
+					setup(mrfs, rf, nil)
+				}
+			}
+
+			handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
+			err := handler.Ensure(rf, map[string]string{}, []metav1.OwnerReference{}, metrics.Dummy)
+
+			assert.Equal(wantErr, err)
 			mrfs.AssertExpectations(t)
 		})
 	}

--- a/operator/redisfailover/handler_test.go
+++ b/operator/redisfailover/handler_test.go
@@ -2,6 +2,7 @@ package redisfailover_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -125,4 +126,203 @@ func TestHandleNotARedisFailover(t *testing.T) {
 	err := handler.Handle(context.Background(), nil)
 
 	assert.Error(err)
+}
+
+// TestHandleValidateError verifies that Handle rejects a RedisFailover that
+// fails Validate() (here, a name longer than the 48-char limit) before ever
+// reaching Ensure or CheckAndHeal.
+func TestHandleValidateError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF(false, true)
+	rf.Name = "this-name-is-far-too-long-to-pass-the-forty-eight-character-limit"
+
+	config := generateConfig()
+	mk := &mK8SService.Services{}
+	mrfc := &mRFService.RedisFailoverCheck{}
+	mrfh := &mRFService.RedisFailoverHeal{}
+	mrfs := &mRFService.RedisFailoverClient{}
+
+	handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
+	err := handler.Handle(context.Background(), rf)
+
+	assert.Error(err)
+	mrfs.AssertNotCalled(t, "EnsureNotPresentRedisService", mock.Anything)
+	mrfc.AssertNotCalled(t, "IsRedisRunning", mock.Anything)
+}
+
+// TestHandleEnsureError verifies that Handle propagates an error from Ensure
+// (the first sub-call it makes) without ever calling CheckAndHeal.
+func TestHandleEnsureError(t *testing.T) {
+	assert := assert.New(t)
+
+	rf := generateRF(false, true) // bootstrapping, no exporter, no sentinels allowed
+	ensureErr := errors.New("ensure boom")
+
+	config := generateConfig()
+	mk := &mK8SService.Services{}
+	mrfc := &mRFService.RedisFailoverCheck{}
+	mrfh := &mRFService.RedisFailoverHeal{}
+	mrfs := &mRFService.RedisFailoverClient{}
+
+	// Only the very first Ensure() call is mocked, and it fails - nothing
+	// after it (in Ensure or CheckAndHeal) should ever be invoked.
+	mrfs.On("EnsureNotPresentRedisService", rf).Once().Return(ensureErr)
+
+	handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
+	err := handler.Handle(context.Background(), rf)
+
+	assert.Equal(ensureErr, err)
+	mrfc.AssertNotCalled(t, "IsRedisRunning", mock.Anything)
+	mrfs.AssertExpectations(t)
+}
+
+// TestHandleCheckAndHealError verifies that Handle propagates an error from
+// CheckAndHeal once Ensure has completed successfully.
+func TestHandleCheckAndHealError(t *testing.T) {
+	assert := assert.New(t)
+
+	// Operator-managed mode (sentinel disabled), not bootstrapping: the
+	// minimal Ensure() call graph (see TestEnsure "don't use exporter" case,
+	// with sentinels also disabled).
+	rf := generateRF(false, false)
+	disabled := false
+	rf.Spec.Sentinel.Enabled = &disabled
+
+	checkErr := errors.New("get number masters boom")
+
+	config := generateConfig()
+	mk := &mK8SService.Services{}
+	mrfc := &mRFService.RedisFailoverCheck{}
+	mrfh := &mRFService.RedisFailoverHeal{}
+	mrfs := &mRFService.RedisFailoverClient{}
+
+	mrfs.On("EnsureNotPresentRedisService", rf).Once().Return(nil)
+	mrfs.On("EnsureNotPresentSentinelResources", rf).Once().Return(nil)
+	mrfs.On("EnsureRedisMasterService", rf, mock.Anything, mock.Anything).Once().Return(nil)
+	mrfs.On("EnsureRedisSlaveService", rf, mock.Anything, mock.Anything).Once().Return(nil)
+	mrfs.On("EnsureRedisShutdownConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
+	mrfs.On("EnsureRedisReadinessConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
+	mrfs.On("EnsureRedisConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
+	mrfs.On("EnsureRedisStatefulset", rf, mock.Anything, mock.Anything).Once().Return(nil)
+
+	// CheckAndHeal routes to checkAndHealOperatorManagedMode and fails at
+	// GetNumberMasters.
+	mrfc.On("IsRedisRunning", rf).Once().Return(true)
+	mrfc.On("GetNumberMasters", rf).Once().Return(0, checkErr)
+
+	handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
+	err := handler.Handle(context.Background(), rf)
+
+	assert.Equal(checkErr, err)
+	mrfs.AssertExpectations(t)
+	mrfc.AssertExpectations(t)
+}
+
+// rfLabelManagedByKeyMirror, rfLabelNameKeyMirror and operatorNameMirror
+// mirror the unexported constants of the same purpose defined in
+// operator/redisfailover/{handler,factory}.go, so tests in this external
+// test package can assert on the labels getLabels() produces.
+const (
+	rfLabelManagedByKeyMirror = "app.kubernetes.io/managed-by"
+	rfLabelNameKeyMirror      = "redisfailovers.databases.spotahome.com/name"
+	operatorNameMirror        = "redis-operator"
+)
+
+// TestHandleGetLabelsWhitelistFiltering exercises getLabels' LabelWhitelist
+// handling (operator/redisfailover/handler.go). getLabels is unexported, so
+// it is reached indirectly through Handle, capturing the labels map Handle
+// passes into Ensure's EnsureRedisMasterService call (which every Ensure()
+// path calls unconditionally).
+func TestHandleGetLabelsWhitelistFiltering(t *testing.T) {
+	tests := []struct {
+		name           string
+		rfLabels       map[string]string
+		whitelist      []string
+		wantIncluded   map[string]string
+		wantExcludedAt []string
+	}{
+		{
+			name:           "no whitelist keeps every custom label",
+			rfLabels:       map[string]string{"team": "cache", "app": "myapp"},
+			whitelist:      nil,
+			wantIncluded:   map[string]string{"team": "cache", "app": "myapp"},
+			wantExcludedAt: nil,
+		},
+		{
+			name:           "whitelist keeps only matching labels",
+			rfLabels:       map[string]string{"team": "cache", "app": "myapp", "unrelated": "x"},
+			whitelist:      []string{"^team$"},
+			wantIncluded:   map[string]string{"team": "cache"},
+			wantExcludedAt: []string{"app", "unrelated"},
+		},
+		{
+			name:           "invalid regex entries are skipped, valid ones still applied",
+			rfLabels:       map[string]string{"app": "myapp", "other": "y"},
+			whitelist:      []string{"(invalid", "^app$"},
+			wantIncluded:   map[string]string{"app": "myapp"},
+			wantExcludedAt: []string{"other"},
+		},
+		{
+			name:           "whitelist matching nothing yields no custom labels",
+			rfLabels:       map[string]string{"app": "myapp"},
+			whitelist:      []string{"^nomatch$"},
+			wantIncluded:   map[string]string{},
+			wantExcludedAt: []string{"app"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			// Bootstrapping, no exporter, no sentinels: minimal Ensure()
+			// call graph (mirrors TestHandleSkipReconcileAnnotation).
+			rf := generateRF(false, true)
+			rf.Labels = test.rfLabels
+			rf.Spec.LabelWhitelist = test.whitelist
+
+			config := generateConfig()
+			mk := &mK8SService.Services{}
+			mrfc := &mRFService.RedisFailoverCheck{}
+			mrfh := &mRFService.RedisFailoverHeal{}
+			mrfs := &mRFService.RedisFailoverClient{}
+
+			var gotLabels map[string]string
+			captureLabels := mock.MatchedBy(func(labels map[string]string) bool {
+				gotLabels = labels
+				return true
+			})
+
+			mrfs.On("EnsureNotPresentRedisService", rf).Once().Return(nil)
+			mrfs.On("EnsureNotPresentSentinelResources", rf).Once().Return(nil)
+			mrfs.On("EnsureRedisMasterService", rf, captureLabels, mock.Anything).Once().Return(nil)
+			mrfs.On("EnsureRedisSlaveService", rf, mock.Anything, mock.Anything).Once().Return(nil)
+			mrfs.On("EnsureRedisConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
+			mrfs.On("EnsureRedisShutdownConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
+			mrfs.On("EnsureRedisReadinessConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
+			mrfs.On("EnsureRedisStatefulset", rf, mock.Anything, mock.Anything).Once().Return(nil)
+
+			mrfc.On("IsRedisRunning", rf).Once().Return(false)
+
+			handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
+			err := handler.Handle(context.Background(), rf)
+			assert.NoError(err)
+
+			if assert.NotNil(gotLabels) {
+				assert.Equal(operatorNameMirror, gotLabels[rfLabelManagedByKeyMirror])
+				assert.Equal(rf.Name, gotLabels[rfLabelNameKeyMirror])
+				for k, v := range test.wantIncluded {
+					assert.Equal(v, gotLabels[k], "expected label %q=%q to be kept", k, v)
+				}
+				for _, k := range test.wantExcludedAt {
+					_, ok := gotLabels[k]
+					assert.False(ok, "expected label %q to be filtered out", k)
+				}
+			}
+
+			mrfs.AssertExpectations(t)
+			mrfc.AssertExpectations(t)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

Raises unit test coverage for the core reconcile loop in `operator/redisfailover`: `checker.go`, `ensurer.go`, and `handler.go`.

Coverage of `operator/redisfailover` package: **69.1% → 92.0%**.

Per-function coverage (before → after):
- `checker.go` `UpdateRedisesPods`: 84.8% → 100%
- `checker.go` `CheckAndHeal`: 62.5% → 100%
- `checker.go` `checkAndHealBootstrapMode`: 69.8% → 100%
- `checker.go` `applyRedisCustomConfig`: 85.7% → 100%
- `checker.go` `checkAndHealSentinels`: 85.0% → 100%
- `ensurer.go` `Ensure`: 58.6% → 100%
- `handler.go` `Handle`: 68.4% → 100%
- `handler.go` `getLabels`: 38.5% → 100%

### What was added
- **`ensurer_test.go`**: `TestEnsureErrorBranches` — table-driven test covering every early-return error branch of `Ensure()`.
- **`handler_test.go`**: `TestHandleValidateError`, `TestHandleEnsureError`, `TestHandleCheckAndHealError` cover `Handle`'s three error-propagation branches. `TestHandleGetLabelsWhitelistFiltering` covers `getLabels`' `LabelWhitelist` regex filtering.
- **`checker_test.go`**: `TestCheckAndHealPlainModeErrorBranches` (19 cases), `TestCheckAndHealBootstrapModeErrorBranches` (5 cases), `TestUpdateRedisesPodsErrorBranches` (7 cases) — cover the reconcile loop's remaining early-return/error branches in both plain and bootstrap mode.

## Two real bugs found and fixed (not just reported)

While writing the coverage tests above, two of `checker.go`'s error branches turned out to diverge from every other error branch in the file — both are now fixed, and the tests that originally documented them as "suspected bugs" now assert the corrected behavior instead.

**1. `checkAndHealBootstrapMode`: `UpdateRedisesPods` error wasn't returned.**
```go
err := r.UpdateRedisesPods(rf)
if err != nil {
    rf.Status = redisfailoverv1.RedisFailoverStatus{
        State:   redisfailoverv1.NotHealthyState,
        Message: "unable to update Redis PODs",
    }
    // missing return err — fell through into applyRedisCustomConfig
}
```
Unlike every other error branch in this file, there was no `return err` — execution fell through into `applyRedisCustomConfig` and beyond, whose result overwrote `err`. If the rest of the function then succeeded, `CheckAndHeal` reported success (`nil`) while `rf.Status` was left claiming `NotHealthyState` with a stale message. **Fixed**: now returns immediately, matching every other branch.

**2. `checkAndHealSentinels` (the final statement of both `CheckAndHeal` and `checkAndHealBootstrapMode`): errors didn't set `rf.Status`.**
Every other error branch in the file sets `rf.Status.State = NotHealthyState` before returning. `checkAndHealSentinels` was the sole exception — on `RestoreSentinel` (x2) or `SetSentinelCustomConfig` failure it returned the error directly without touching `rf.Status`. Since `CheckAndHeal` sets `HealthyState` unconditionally at the top and relies on each error path to override it, a failure here left the CR's reported status claiming `Healthy` while the reconcile had actually failed. **Fixed**: each of the three error paths now sets `NotHealthyState` with a descriptive message, matching the rest of the file.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./operator/redisfailover/...`
- [x] `go test ./...` (full repo)
- [x] `golangci-lint run --no-config ./operator/redisfailover/...` → 0 issues