### PR TITLE
fix: SentinelCheckQuorum NOQUORUM dead code + MakeSlaveOfWithPort wrong port

### DIFF
--- a/mocks/service/redis/Client.go
+++ b/mocks/service/redis/Client.go
@@ -168,13 +168,13 @@ func (_m *Client) MakeSlaveOf(ip string, masterIP string, password string) error
 	return r0
 }
 
-// MakeSlaveOfWithPort provides a mock function with given fields: ip, masterIP, masterPort, password
-func (_m *Client) MakeSlaveOfWithPort(ip string, masterIP string, masterPort string, password string) error {
-	ret := _m.Called(ip, masterIP, masterPort, password)
+// MakeSlaveOfWithPort provides a mock function with given fields: ip, port, masterIP, masterPort, password
+func (_m *Client) MakeSlaveOfWithPort(ip string, port string, masterIP string, masterPort string, password string) error {
+	ret := _m.Called(ip, port, masterIP, masterPort, password)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
-		r0 = rf(ip, masterIP, masterPort, password)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, string) error); ok {
+		r0 = rf(ip, port, masterIP, masterPort, password)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/operator/redisfailover/service/heal.go
+++ b/operator/redisfailover/service/heal.go
@@ -133,7 +133,7 @@ func (r *RedisFailoverHealer) SetOldestAsMaster(rf *redisfailoverv1.RedisFailove
 			newMasterIP = pod.Status.PodIP
 		} else {
 			r.logger.Infof("Making pod %s slave of %s", pod.Name, newMasterIP)
-			if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, newMasterIP, port, password); err != nil {
+			if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, port, newMasterIP, port, password); err != nil {
 				r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).Errorf("Make slave failed, slave pod ip: %s, master ip: %s, error: %v", pod.Status.PodIP, newMasterIP, err)
 			}
 
@@ -199,7 +199,7 @@ func (r *RedisFailoverHealer) SetMasterOnAll(masterIP string, rf *redisfailoverv
 				continue
 			}
 			r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).Infof("Making pod %s slave of %s", pod.Name, masterIP)
-			if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, masterIP, port, password); err != nil {
+			if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, port, masterIP, port, password); err != nil {
 				r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).Errorf("Make slave failed, slave ip: %s, master ip: %s, error: %v", pod.Status.PodIP, masterIP, err)
 				return err
 			}
@@ -226,9 +226,13 @@ func (r *RedisFailoverHealer) SetExternalMasterOnAll(masterIP, masterPort string
 		return err
 	}
 
+	// The target pods' own port, which is not necessarily masterPort - the
+	// external bootstrap master can be configured on a different port than
+	// this RedisFailover's own Redis pods.
+	port := getRedisPort(rf.Spec.Redis.Port)
 	for _, pod := range ssp.Items {
 		r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).Infof("Making pod %s slave of %s:%s", pod.Name, masterIP, masterPort)
-		if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, masterIP, masterPort, password); err != nil {
+		if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, port, masterIP, masterPort, password); err != nil {
 			return err
 		}
 
@@ -355,7 +359,7 @@ func (r *RedisFailoverHealer) PromoteBestReplica(newMasterIP string, rf *redisfa
 		r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).
 			Infof("Making pod %s slave of %s", rp.Name, newMasterIP)
 
-		if err := r.redisClient.MakeSlaveOfWithPort(rp.Status.PodIP, newMasterIP, port, password); err != nil {
+		if err := r.redisClient.MakeSlaveOfWithPort(rp.Status.PodIP, port, newMasterIP, port, password); err != nil {
 			r.logger.WithField("redisfailover", rf.Name).WithField("namespace", rf.Namespace).
 				Errorf("Failed to make %s slave of %s: %v", rp.Status.PodIP, newMasterIP, err)
 			reconcileErrs = append(reconcileErrs, err)

--- a/operator/redisfailover/service/heal_test.go
+++ b/operator/redisfailover/service/heal_test.go
@@ -96,7 +96,7 @@ func TestSetOldestAsMasterMultiplePodsMakeSlaveOfError(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "0.0.0.0", "0", "").Once().Return(nil)
-	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(errors.New(""))
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "0.0.0.0", "0", "").Once().Return(errors.New(""))
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -129,7 +129,7 @@ func TestSetOldestAsMasterMultiplePods(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "0.0.0.0", "0", "").Once().Return(nil)
-	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "0.0.0.0", "0", "").Once().Return(nil)
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -172,7 +172,7 @@ func TestSetOldestAsMasterOrdering(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "1.1.1.1", "0", "").Once().Return(nil)
-	mr.On("MakeSlaveOfWithPort", "0.0.0.0", "1.1.1.1", "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", "0.0.0.0", "0", "1.1.1.1", "0", "").Once().Return(nil)
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -236,7 +236,7 @@ func TestSetMasterOnAllMakeSlaveOfError(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("IsMaster", "0.0.0.0", "0", "").Return(true, nil)
-	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(errors.New(""))
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "0.0.0.0", "0", "").Once().Return(errors.New(""))
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -269,7 +269,7 @@ func TestSetMasterOnAll(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("IsMaster", "0.0.0.0", "0", "").Return(true, nil)
-	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "0.0.0.0", "0", "").Once().Return(nil)
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -332,7 +332,7 @@ func TestSetMasterOnAllSlaveAlreadyLabeled(t *testing.T) {
 	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(pods, nil)
 	mr := &mRedisService.Client{}
 	mr.On("IsMaster", "0.0.0.0", "0", "").Return(true, nil)
-	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "0.0.0.0", "0", "").Once().Return(nil)
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -391,12 +391,12 @@ func TestSetExternalMasterOnAll(t *testing.T) {
 
 			mr := &mRedisService.Client{}
 			if !expectError {
-				mr.On("MakeSlaveOfWithPort", "0.0.0.0", "5.5.5.5", "6379", "").Once().Return(nil)
+				mr.On("MakeSlaveOfWithPort", "0.0.0.0", "0", "5.5.5.5", "6379", "").Once().Return(nil)
 				if test.errorOnMakeSlaveOf {
 					expectError = true
-					mr.On("MakeSlaveOfWithPort", "1.1.1.1", "5.5.5.5", "6379", "").Once().Return(errors.New(""))
+					mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "5.5.5.5", "6379", "").Once().Return(errors.New(""))
 				} else {
-					mr.On("MakeSlaveOfWithPort", "1.1.1.1", "5.5.5.5", "6379", "").Once().Return(nil)
+					mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "5.5.5.5", "6379", "").Once().Return(nil)
 				}
 			}
 
@@ -447,7 +447,7 @@ func TestPromoteBestReplicaSuccess(t *testing.T) {
 
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", newMasterIP, "0", "").Once().Return(nil)
-	mr.On("MakeSlaveOfWithPort", replicaIP, newMasterIP, "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", replicaIP, "0", newMasterIP, "0", "").Once().Return(nil)
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -489,7 +489,7 @@ func TestPromoteBestReplicaReplicaRepointerFails(t *testing.T) {
 
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", newMasterIP, "0", "").Once().Return(nil)
-	mr.On("MakeSlaveOfWithPort", replicaIP, newMasterIP, "0", "").Once().Return(errors.New("replica repoint failed"))
+	mr.On("MakeSlaveOfWithPort", replicaIP, "0", newMasterIP, "0", "").Once().Return(errors.New("replica repoint failed"))
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -533,7 +533,7 @@ func TestPromoteBestReplicaLabelUpdateFails(t *testing.T) {
 
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", newMasterIP, "0", "").Once().Return(nil)
-	mr.On("MakeSlaveOfWithPort", replicaIP, newMasterIP, "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", replicaIP, "0", newMasterIP, "0", "").Once().Return(nil)
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 

--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -37,7 +37,7 @@ type Client interface {
 	MonitorRedisWithPort(ip, monitor, port, quorum, password string) error
 	MakeMaster(ip, port, password string) error
 	MakeSlaveOf(ip, masterIP, password string) error
-	MakeSlaveOfWithPort(ip, masterIP, masterPort, password string) error
+	MakeSlaveOfWithPort(ip, port, masterIP, masterPort, password string) error
 	GetSentinelMonitor(ip string) (string, string, error)
 	SetCustomSentinelConfig(ip string, configs []string) error
 	SetCustomRedisConfig(ip string, port string, configs []string, password string) error
@@ -320,12 +320,17 @@ func (c *client) MakeMaster(ip string, port string, password string) error {
 }
 
 func (c *client) MakeSlaveOf(ip, masterIP, password string) error {
-	return c.MakeSlaveOfWithPort(ip, masterIP, redisPort, password)
+	return c.MakeSlaveOfWithPort(ip, redisPort, masterIP, redisPort, password)
 }
 
-func (c *client) MakeSlaveOfWithPort(ip, masterIP, masterPort, password string) error {
+// MakeSlaveOfWithPort reconfigures the Redis instance at ip:port to become a
+// replica of masterIP:masterPort. port is the target's own listening port -
+// it must not be assumed to equal masterPort, since a target and its master
+// can be configured with different ports (e.g. Bootstrapping mode's
+// externally supplied master port).
+func (c *client) MakeSlaveOfWithPort(ip, port, masterIP, masterPort, password string) error {
 	options := &rediscli.Options{
-		Addr:     net.JoinHostPort(ip, masterPort), // this is IP and Port for the RedisFailover redis
+		Addr:     net.JoinHostPort(ip, port),
 		Password: password,
 		DB:       0,
 	}
@@ -418,6 +423,17 @@ func (c *client) SentinelCheckQuorum(ip string) error {
 	res, err := cmd.Result()
 
 	if err != nil {
+		// SENTINEL CKQUORUM's NOQUORUM outcome comes back over the wire as a
+		// genuine RESP error whose text starts with "NOQUORUM", not as a
+		// successful string reply - so it has to be classified here, before
+		// the success-path string parsing below (which can only ever see
+		// the "OK ..." success message, since res is empty whenever err is
+		// non-nil).
+		if strings.Contains(err.Error(), "NOQUORUM") {
+			log.Debugf("SentinelCheckQuorum: quorum not available: %s", err.Error())
+			c.metricsRecorder.RecordRedisOperation(metrics.KIND_SENTINEL, ip, metrics.CHECK_SENTINEL_QUORUM, metrics.SUCCESS, "NOQUORUM")
+			return fmt.Errorf("quorum Not available")
+		}
 		log.Warnf("Unable to get result for CKQUORUM comand")
 		c.metricsRecorder.RecordRedisOperation(metrics.KIND_SENTINEL, ip, metrics.CHECK_SENTINEL_QUORUM, metrics.FAIL, getRedisError(err))
 		return err
@@ -425,18 +441,8 @@ func (c *client) SentinelCheckQuorum(ip string) error {
 	log.Debugf("SentinelCheckQuorum cmd result: %s", res)
 	s := strings.Split(res, " ")
 	status := s[0]
-	quorum := s[1]
 
-	if status == "" {
-		log.Errorf("quorum command result unexpected output")
-		c.metricsRecorder.RecordRedisOperation(metrics.KIND_SENTINEL, ip, metrics.CHECK_SENTINEL_QUORUM, metrics.FAIL, "quorum command result unexpected output")
-		return fmt.Errorf("quorum command result unexpected output")
-	}
-	if status == "(error)" && quorum == "NOQUORUM" {
-		c.metricsRecorder.RecordRedisOperation(metrics.KIND_SENTINEL, ip, metrics.CHECK_SENTINEL_QUORUM, metrics.SUCCESS, "NOQUORUM")
-		return fmt.Errorf("quorum Not available")
-
-	} else if status == "OK" {
+	if status == "OK" {
 		c.metricsRecorder.RecordRedisOperation(metrics.KIND_SENTINEL, ip, metrics.CHECK_SENTINEL_QUORUM, metrics.SUCCESS, "QUORUM")
 		return nil
 	} else {

--- a/service/redis/client_test.go
+++ b/service/redis/client_test.go
@@ -6,12 +6,14 @@ package redis
 // though it is the entire wire-protocol layer the operator uses to talk to
 // Redis and Sentinel.
 //
-// Two behaviours here were verified empirically against real Redis 7.0.15
-// rather than assumed, per the investigation that prompted this test suite:
-//   - SENTINEL CKQUORUM's NOQUORUM outcome (see TestSentinelCheckQuorum_NoQuorum).
+// Several behaviours here were verified empirically against real Redis
+// 7.0.15 rather than assumed, per the investigation that prompted this test
+// suite - each surfaced a real bug in client.go, fixed in the same change
+// as its test:
 //   - CONFIG SET aclfile's immutability (see TestSetCustomRedisConfig_ACLFile).
-// The aclfile finding surfaced a real bug in client.go, fixed in the same
-// change as this test (see the comment on TestSetCustomRedisConfig_ACLFile).
+//   - SENTINEL CKQUORUM's NOQUORUM outcome (see TestSentinelCheckQuorum_NoQuorum).
+//   - MakeSlaveOfWithPort connecting to the master's port instead of the
+//     target's own port (see TestMakeSlaveOfWithPort_MismatchedTargetPort).
 
 import (
 	"context"
@@ -243,18 +245,15 @@ func TestMakeMaster_ConnectionError(t *testing.T) {
 	assert.Error(t, err)
 }
 
-// TestMakeSlaveOfWithPort_ConnectionError points at a port nothing is
-// listening on to exercise MakeSlaveOfWithPort's own connection-error
-// branch. It intentionally does not attempt to also reach a real master -
-// see TestMakeSlaveOfWithPort_MismatchedTargetPort for why the address
-// MakeSlaveOfWithPort actually connects to is (ip, masterPort), not
-// (ip, targetPort).
+// TestMakeSlaveOfWithPort_ConnectionError points the target's own port at a
+// port nothing is listening on to exercise MakeSlaveOfWithPort's own
+// connection-error branch.
 func TestMakeSlaveOfWithPort_ConnectionError(t *testing.T) {
 	port, err := findFreePort()
 	require.NoError(t, err)
 	c := newTestClient()
 
-	err = c.MakeSlaveOfWithPort(testLoopbackIP, "10.0.0.1", strconv.Itoa(port), "")
+	err = c.MakeSlaveOfWithPort(testLoopbackIP, strconv.Itoa(port), "10.0.0.1", "6379", "")
 	assert.Error(t, err)
 }
 
@@ -309,7 +308,7 @@ func TestMakeSlaveOfWithPort_SamePortDifferentIP(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, isMaster)
 
-	err = c.MakeSlaveOfWithPort(a.IP, b.IP, strconv.Itoa(b.Port), "")
+	err = c.MakeSlaveOfWithPort(a.IP, strconv.Itoa(a.Port), b.IP, strconv.Itoa(b.Port), "")
 	require.NoError(t, err)
 
 	waitForCondition(t, 5*time.Second, func() bool {
@@ -327,55 +326,47 @@ func TestMakeSlaveOfWithPort_SamePortDifferentIP(t *testing.T) {
 	assert.True(t, linkUp)
 }
 
-// TestMakeSlaveOfWithPort_MismatchedTargetPort documents a real bug found
-// while building this test suite (not fixed here, per instructions - see
-// the task summary for the full report):
+// TestMakeSlaveOfWithPort_MismatchedTargetPort covers a real bug found while
+// building this test suite: MakeSlaveOfWithPort used to have no separate
+// parameter for the target's own port, and connected to the *target* at
+// `net.JoinHostPort(ip, masterPort)` - i.e. it used the *master's* port to
+// reach the target. That was only correct when the target and the master
+// happened to share a port number (true in this operator's normal
+// deployment model - see TestMakeSlaveOfWithPort_SamePortDifferentIP for
+// that case). When the target's actual port differed from the master's
+// port (reachable via Bootstrapping's externally supplied master port),
+// this silently connected to the wrong instance rather than failing loudly.
 //
-// MakeSlaveOfWithPort(ip, masterIP, masterPort, password) connects to the
-// *target* redis instance (the one it's about to issue SLAVEOF against) at
-// `net.JoinHostPort(ip, masterPort)` - i.e. it uses the *master's* port to
-// reach the target, with no separate parameter for the target's own port.
-// That's only correct when the target and the master happen to listen on
-// the same port number (true in this operator's normal deployment model,
-// where every managed Redis instance uses one shared configured port across
-// different pod IPs - see the SamePortDifferentIP test above for that
-// case). When the target's actual port differs from the master's port, this
-// silently does the wrong thing rather than failing loudly:
-//
-// Here `a` (the intended target) and `b` (the intended master) share the
-// same IP (both loopback) but listen on *different* ports. Calling
-// MakeSlaveOfWithPort(a.IP, b.IP, b.Port, "") computes the connection
-// address as (a.IP, b.Port) - since a.IP == b.IP, that address actually
-// belongs to `b`'s own server, not `a`'s. The client ends up connected to
-// `b` and issues `SLAVEOF b.IP b.Port` *to b itself*. Real Redis accepts
-// `SLAVEOF <self>` without error (confirmed manually against 7.0.15) and
-// becomes a slave of itself with master_link_status permanently "down" -
-// so the call returns a misleading nil error, `b` is left in a broken
-// self-replicating state, and `a` (the actual intended target) is never
-// contacted at all and remains an untouched master.
+// MakeSlaveOfWithPort now takes an explicit port for the target, separate
+// from masterPort. Here `a` (the target) and `b` (the master) share the
+// same IP (both loopback) but listen on *different* ports - exactly the
+// case that used to misroute the connection to `b` itself. This asserts
+// the fix: `a` is correctly reconfigured as a replica of `b`, and `b` is
+// left untouched as a master.
 func TestMakeSlaveOfWithPort_MismatchedTargetPort(t *testing.T) {
 	requireRedisServer(t)
 	a := startRedisProcess(t)
 	b := startRedisProcess(t)
 	c := newTestClient()
-	require.NotEqual(t, a.Port, b.Port, "test setup requires distinct ports to reproduce the bug")
+	require.NotEqual(t, a.Port, b.Port, "test setup requires distinct ports to exercise the target/master port distinction")
 
-	err := c.MakeSlaveOfWithPort(a.IP, b.IP, strconv.Itoa(b.Port), "")
-	require.NoError(t, err, "the call itself does not surface an error - that's the point of this bug")
-
-	// `a`, the intended target, was never actually reached.
-	masterOf, err := c.GetSlaveOf(a.IP, strconv.Itoa(a.Port), "")
+	err := c.MakeSlaveOfWithPort(a.IP, strconv.Itoa(a.Port), b.IP, strconv.Itoa(b.Port), "")
 	require.NoError(t, err)
-	assert.Empty(t, masterOf, "the intended target should be untouched, still a master")
 
-	// `b` was told to replicate from itself instead.
-	waitForCondition(t, 2*time.Second, func() bool {
-		masterOf, err := c.GetSlaveOf(b.IP, strconv.Itoa(b.Port), "")
+	// `a`, the actual target, should be reconfigured as a replica of `b`.
+	waitForCondition(t, 5*time.Second, func() bool {
+		masterOf, err := c.GetSlaveOf(a.IP, strconv.Itoa(a.Port), "")
 		return err == nil && masterOf == b.IP
 	})
+	masterOf, err := c.GetSlaveOf(a.IP, strconv.Itoa(a.Port), "")
+	require.NoError(t, err)
+	assert.Equal(t, b.IP, masterOf, "the target should be reconfigured as a replica of the intended master")
+
+	// `b`, the master, should be untouched - still its own master, not
+	// pointed at itself or at `a`.
 	masterOf, err = c.GetSlaveOf(b.IP, strconv.Itoa(b.Port), "")
 	require.NoError(t, err)
-	assert.Equal(t, b.IP, masterOf, "the master ends up pointed at itself instead of the target being reconfigured")
+	assert.Empty(t, masterOf, "the master should be untouched, still a master")
 }
 
 // TestMakeSlaveOf covers the MakeSlaveOf convenience wrapper, which hardcodes
@@ -767,30 +758,23 @@ func TestSentinelCheckQuorum_OK(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-// TestSentinelCheckQuorum_NoQuorum documents a real bug found while building
-// this test suite (not fixed here, per instructions - see the task summary
-// for the full report):
+// TestSentinelCheckQuorum_NoQuorum covers a real bug found while building
+// this test suite: real Sentinel's CKQUORUM reply for the NOQUORUM case
+// comes back as a RESP *error* reply (confirmed here against real Redis
+// 7.0.15: `redis-cli --no-raw` shows `(error) NOQUORUM ...`), not as a
+// successful string reply whose text happens to start with the literal
+// characters "(error)". Since go-redis's SentinelClient.CkQuorum uses a
+// StringCmd, that RESP error becomes cmd.Err()/the err returned by
+// cmd.Result() - so client.go's SentinelCheckQuorum used to take its `if
+// err != nil { ... return err }` branch immediately, and its own intended
+// NOQUORUM handling (checking `s := strings.Split(res, " ")` for a literal
+// "(error)"/"NOQUORUM" pair) could never execute, since res is only
+// non-empty when err is nil.
 //
-// Real Sentinel's CKQUORUM reply for the NOQUORUM case comes back as a RESP
-// *error* reply (confirmed here against real Redis 7.0.15: `redis-cli
-// --no-raw` shows `(error) NOQUORUM ...`), not as a successful string reply
-// whose text happens to start with the literal characters "(error)". Since
-// go-redis's SentinelClient.CkQuorum uses a StringCmd, that RESP error
-// becomes cmd.Err()/the err returned by cmd.Result() - so
-// client.go's SentinelCheckQuorum takes its `if err != nil { ... return err
-// }` branch immediately.
-//
-// The subsequent code - `s := strings.Split(res, " ")` followed by `if
-// status == "(error)" && quorum == "NOQUORUM"` - can therefore never
-// execute on a real NOQUORUM response: `res` is only non-empty when err is
-// nil, i.e. only for the OK case, so status will always be "OK" whenever
-// that branch is reached. In other words, the code's own intended NOQUORUM
-// handling (returning `errors.New("quorum Not available")`) is dead code;
-// what actually gets returned to callers today is the raw driver error
-// (whose message happens to also mention NOQUORUM, so callers checking
-// err != nil for failure still work correctly - this is a
-// dead-code/messaging bug, not a functional regression for existing
-// callers as far as we can tell).
+// SentinelCheckQuorum now classifies NOQUORUM directly from err.Error()
+// (which real Sentinel prefixes with "NOQUORUM ...") before the
+// success-path string parsing, restoring the intended "quorum Not
+// available" message and NOQUORUM metrics tag.
 // ---------------------------------------------------------------------
 // getRedisError
 //
@@ -830,6 +814,7 @@ func TestSentinelCheckQuorum_NoQuorum(t *testing.T) {
 
 	err = c.SentinelCheckQuorum(env.sentinel.IP)
 	require.Error(t, err, "CKQUORUM should fail when quorum exceeds the number of known sentinels")
+	assert.Equal(t, "quorum Not available", err.Error(), "the intended NOQUORUM message should be reachable, not just the raw driver error")
 }
 
 // TestSentinelFunctions_SentinelUnreachable exercises the connection-error


### PR DESCRIPTION
## Summary

Two real bugs found and fixed in `service/redis/client.go`, both confirmed against real Redis/Sentinel 7.0.15 (and cross-checked against Valkey 7.2.12 in the investigation that surfaced them).

### 1. `SentinelCheckQuorum`'s NOQUORUM handling was dead code

Real Sentinel's `SENTINEL CKQUORUM` reply for the NOQUORUM case comes back as a genuine RESP **error** reply, not a successful string reply whose text happens to start with `"(error)"`. Since go-redis's `CkQuorum` surfaces that as `cmd.Err()`, the function's `if err != nil { return err }` branch fired immediately — the subsequent string-parsing code that checked for `status == "(error)" && quorum == "NOQUORUM"` could never execute, since `res` is only non-empty when `err` is nil. Callers still correctly saw a non-nil error (the raw driver error happens to mention NOQUORUM too), but the intended `"quorum Not available"` message and `NOQUORUM` metrics tag never fired.

**Fix**: NOQUORUM is now classified directly from `err.Error()` (which real Sentinel prefixes with `"NOQUORUM ..."`) before the now-simplified success-path parsing. Verified against a real Sentinel process — `TestSentinelCheckQuorum_NoQuorum` now asserts the exact restored message.

### 2. `MakeSlaveOfWithPort` connected to the target using the *master's* port

`MakeSlaveOfWithPort(ip, masterIP, masterPort, password)` dialed the target Redis instance at `net.JoinHostPort(ip, masterPort)` — using the master's port to reach the target, with no parameter for the target's own port. This only worked by coincidence: every caller except `SetExternalMasterOnAll` passes the same port for both target and master (both come from `spec.redis.port` on the same RedisFailover). `SetExternalMasterOnAll`'s externally-supplied Bootstrapping master port (`spec.bootstrapNode.port`) can genuinely differ from `spec.redis.port` — in which case the client silently connected to the wrong port (or, if target and master share an IP, ended up issuing `SLAVEOF` to the master itself, which Redis accepts without error) instead of failing loudly.

**Fix**: `MakeSlaveOfWithPort` now takes an explicit `port` for the target, separate from `masterPort`. Updated the interface, all four call sites in `heal.go` (`SetOldestAsMaster`, `SetMasterOnAll`, `SetExternalMasterOnAll`, `PromoteBestReplica`), the `MakeSlaveOf` convenience wrapper, the generated mock, and all affected tests. Verified against two real, independently-addressable Redis instances on different ports — `TestMakeSlaveOfWithPort_MismatchedTargetPort` now asserts the target is correctly reconfigured and the master is left untouched.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full repo, including real redis-server/sentinel subprocess tests, ~17s)
- [x] `golangci-lint run --no-config ./service/redis/... ./operator/redisfailover/... ./mocks/...` — 0 issues
- [x] `gofmt -l` on all changed files — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4mmyo3sqLwf23m5FE2nBE)_